### PR TITLE
C ABI, Unregistering Controllers, Nix Tinkering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ Testing/
 vgcore.*
 callgrind.out.*
 *.svg
+.cache

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,30 @@
       in
       {
         devShells.default = pkgs.mkShell {
-          packages = buildPackages ++ [ pkgs.git ];
+          packages = buildPackages ++ [
+            pkgs.git
+            pkgs.gtest
+            pkgs.clang_19
+            pkgs.clang-tools
+            pkgs.llvmPackages_19.libcxx
+          ];
+          
+          # Set Clang as the default compiler
+          shellHook = ''
+            CLANG_RESOURCE_DIR=$(${pkgs.clang_19}/bin/clang -print-resource-dir)
+            LIBCXX=${pkgs.llvmPackages_19.libcxx}
+            
+            # Set up clang-tidy cache
+            mkdir -p .cache
+            export CLANG_TIDY_USE_CACHE=1
+            export CLANG_TIDY_CACHE_DIR="$(pwd)/.cache"
+            
+          '';
+
+          stdenv = pkgs.clangStdenv.override {
+            cc = pkgs.llvmPackages_19.clang;
+            libcxx = pkgs.llvmPackages_19.libcxx;
+          };
         };
 
         packages = rec {

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  flake = (builtins.getFlake (toString ./.));
+  devShell = flake.devShells.${pkgs.system}.default;
+in
+pkgs.mkShell {
+  buildInputs = devShell.buildInputs or [];
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(controllers)
 add_subdirectory(statefunctions)
 add_subdirectory(types)
 add_subdirectory(analysis)
+add_subdirectory(capi)
 
 get_target_property(libmahjong_includes libmahjong HEADER_SET)
 target_precompile_headers(libmahjong PRIVATE ${libmahjong_includes})

--- a/src/capi/CMakeLists.txt
+++ b/src/capi/CMakeLists.txt
@@ -1,0 +1,8 @@
+target_sources(libmahjong
+    PRIVATE
+        capi.cc
+    PUBLIC
+        FILE_SET HEADERS
+        FILES
+            capi.h
+)

--- a/src/capi/capi.cc
+++ b/src/capi/capi.cc
@@ -1,0 +1,260 @@
+#include "capi.h"
+#include "statefunctions/statecontroller.h"
+#include "types/settings.h"
+#include "types/gamestate.h"
+#include "controllers/controllermanager.h"
+#include "controllers/playercontroller.h"
+#include <cstring>
+#include <string>
+#include <map>
+#include <vector>
+
+extern "C" {
+
+/**
+* Opaque Type Wrappers
+*/
+
+struct GameStateWrapper {
+    std::unique_ptr<mahjong::GameState> state;
+};
+
+struct PlayerControllerWrapper {
+    std::unique_ptr<mahjong::PlayerController> controller;
+};
+
+/**
+* External Player Controller
+*/
+
+class ExternalPlayerController : public mahjong::PlayerController {
+public:
+    ExternalPlayerController(ControllerCallbacks callbacks)
+        : callbacks(callbacks) {}
+
+    static std::unique_ptr<mahjong::PlayerController> New() {
+        return nullptr;
+    }
+
+    void GameStart(int player_id) override {
+        if (callbacks.onGameStart)
+            callbacks.onGameStart(callbacks.userData, player_id);
+    }
+
+    void RoundStart(std::vector<mahjong::Piece> hand, mahjong::Wind seat_wind, mahjong::Wind prevalent_wind) override {
+        if (callbacks.onRoundStart) {
+            // Pieces to CPiece array
+            std::vector<CPiece> cHand;
+            cHand.reserve(hand.size());
+            for (const auto& piece : hand) {
+                cHand.push_back(piece.toUint8_t());
+            }
+            
+            // Vector to CPiece array
+            // Due to the rules of mahjong, clients will be able to make an assumption
+            // for the length of this hand, so we don't need to send the array size
+            // along with it
+            CPiece* handCopy = new CPiece[cHand.size()];
+            std::memcpy(handCopy, cHand.data(), cHand.size() * sizeof(CPiece));
+            
+            callbacks.onRoundStart(
+                callbacks.userData,
+                handCopy,
+                static_cast<int>(cHand.size()),
+                static_cast<CWind>(seat_wind),
+                static_cast<CWind>(prevalent_wind)
+            );
+            
+            // We pass handCopy is a piece pointer
+            // The callback is responsible for copying the data if needed
+            // We free the memory to avoid a leak
+            delete[] handCopy;
+        }
+    }
+
+    void ReceiveEvent(mahjong::Event e) override {
+        if (callbacks.onReceiveEvent) {
+            CEvent cEvent;
+            cEvent.type = static_cast<int>(e.type);
+            cEvent.player = e.player;
+            cEvent.piece = e.piece;
+            cEvent.decision = e.decision;
+            
+            callbacks.onReceiveEvent(callbacks.userData, cEvent);
+        }
+    }
+
+    mahjong::Event RetrieveDecision() override {
+        if (callbacks.onRetrieveDecision) {
+            CEvent cEvent = callbacks.onRetrieveDecision(callbacks.userData);
+            
+            mahjong::Event e;
+            e.type = static_cast<mahjong::Event::Type>(cEvent.type);
+            e.player = cEvent.player;
+            e.piece = cEvent.piece;
+            e.decision = cEvent.decision;
+            
+            return e;
+        }
+        return mahjong::kDeclineEvent;
+    }
+
+    std::string Name() override {
+        if (callbacks.getName)
+            return callbacks.getName(callbacks.userData);
+        return "External Controller";
+    }
+
+private:
+    ControllerCallbacks callbacks;
+};
+
+/**
+* Game Control
+*/
+
+static std::map<std::string, ControllerCallbacks> registeredControllers;
+
+mahjong::GameSettings convertGameSettings(const GameSettings* settings) {
+    mahjong::GameSettings cppSettings;
+    
+    cppSettings.seed = settings->seed;
+    
+    // Char arrays to vector
+    if (settings->seatControllers && settings->numControllers > 0) {
+        for (size_t i = 0; i < settings->numControllers; i++) {
+            if (settings->seatControllers[i]) {
+                cppSettings.seatControllers.push_back(settings->seatControllers[i]);
+            }
+        }
+    }
+    
+    if (settings->overrideWall) {
+        // We don't really have a great way to go from standard override wall to
+        // C type, since we don't have an easy length indicator.
+        // For now, treating it like a string, with each char being a piece
+        std::string wallStr(settings->overrideWall);
+        std::vector<mahjong::Piece> wallPieces;
+        
+        for (size_t i = 0; i < wallStr.length(); i++) {
+            uint8_t pieceValue = static_cast<uint8_t>(wallStr[i]);
+            wallPieces.push_back(mahjong::Piece(pieceValue));
+        }
+        
+        cppSettings.overrideWall = wallPieces;
+    }
+    
+    return cppSettings;
+}
+
+int StartGame(const GameSettings* settings, int async) {
+    mahjong::GameSettings cppSettings = convertGameSettings(settings);
+    return mahjong::StartGame(cppSettings, async != 0);
+}
+
+void ExitGame(int game) {
+    mahjong::ExitGame(game);
+}
+
+GameState* InitGameState(const GameSettings* settings) {
+    mahjong::GameSettings cppSettings = convertGameSettings(settings);
+    auto state = mahjong::InitGameState(cppSettings);
+    return new GameStateWrapper{ std::move(state) };
+}
+
+GameState* AdvanceGameState(GameState* state) {
+    auto wrapper = static_cast<GameStateWrapper*>(state);
+    auto newState = mahjong::AdvanceGameState(std::move(wrapper->state));
+    delete wrapper;
+    return new GameStateWrapper{ std::move(newState) };
+}
+
+void DestroyGameState(GameState* state) {
+    auto wrapper = static_cast<GameStateWrapper*>(state);
+    delete wrapper;
+}
+
+/**
+* Controller Management
+*/
+
+char** GetAvailableControllers(size_t* count) {
+    auto controllers = mahjong::ControllerManager::Instance().GetAvailableControllers();
+    *count = controllers.size();
+    
+    char** result = (char**)malloc(sizeof(char*) * controllers.size());
+    for (size_t i = 0; i < controllers.size(); i++) {
+        result[i] = strdup(controllers[i].c_str());
+    }
+    
+    return result;
+}
+
+// Registers callbacks for a given controller name
+int RegisterController(const char* name, ControllerCallbacks callbacks) {
+    std::string controllerName(name);
+    registeredControllers[controllerName] = callbacks;
+    
+    auto factory = [controllerName]() -> std::unique_ptr<mahjong::PlayerController> {
+        return std::make_unique<ExternalPlayerController>(registeredControllers[controllerName]);
+    };
+    
+    return mahjong::ControllerManager::Instance().RegisterController(factory, controllerName);
+}
+
+// Creates a new controller instance, which points to the function callbacks
+PlayerControllerWrapper* CreateController(const char* name) {
+    try {
+        auto controller = mahjong::ControllerManager::Instance().NewController(name);
+        return new PlayerControllerWrapper { std::move(controller) };
+    }
+    catch (...) {
+        return nullptr;
+    }
+}
+
+int UnregisterController(const char* name) {
+    std::string controllerName(name);
+    auto it = registeredControllers.find(controllerName);
+    if (it != registeredControllers.end()) {
+        registeredControllers.erase(it);
+        return mahjong::ControllerManager::Instance().UnregisterController(controllerName);
+    }
+    // Controller wasn't found
+    return 0;
+}
+
+void FreeGameSettings(GameSettings* settings) {
+    if (!settings) return;
+    
+    // Free seat controllers
+    if (settings->seatControllers) {
+        for (size_t i = 0; i < settings->numControllers; i++) {
+            free(settings->seatControllers[i]);
+        }
+        free(settings->seatControllers);
+        settings->seatControllers = nullptr;
+    }
+    
+    // Free override wall
+    if (settings->overrideWall) {
+        free(settings->overrideWall);
+        settings->overrideWall = nullptr;
+    }
+    
+    settings->numControllers = 0;
+}
+
+
+void FreeControllerList(char** list, size_t count) {
+    for (size_t i = 0; i < count; i++) {
+        free(list[i]);
+    }
+    free(list);
+}
+
+void DestroyController(PlayerControllerWrapper* controller) {
+    delete controller;
+}
+
+} // extern "C"

--- a/src/capi/capi.h
+++ b/src/capi/capi.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/****
+* C Game Types
+*/
+
+typedef uint8_t CPiece;
+typedef uint8_t CWind;
+
+typedef struct CEvent {
+    uint8_t type;
+    int player;
+    int16_t piece;
+    bool decision;
+} CEvent;
+
+typedef struct CGameSettings {
+    unsigned int seed;
+    char** seatControllers; // Array of controller names
+    size_t numControllers;  // Number of controllers
+    char* overrideWall;     // Optional override wall
+} GameSettings;
+
+// Opaque Types
+typedef struct GameStateWrapper GameState;
+typedef struct PlayerControllerWrapper PlayerController;
+
+/***
+* Game Control
+*/
+
+int StartGame(const GameSettings* settings, int async);
+void ExitGame(int game);
+GameState* InitGameState(const GameSettings* settings);
+GameState* AdvanceGameState(GameState* state); 
+void DestroyGameState(GameState* state);
+
+/*****
+* Game Controller
+*/
+
+// Callback function types for PlayerController interface
+typedef void (*GameStartFunc)(void* userData, int playerId);
+typedef void (*RoundStartFunc)(void* userData, CPiece* hand, int handSize, CWind seatWind, CWind prevalentWind);
+typedef void (*ReceiveEventFunc)(void* userData, CEvent event);
+typedef CEvent (*RetrieveDecisionFunc)(void* userData);
+typedef const char* (*GetNameFunc)(void* userData);
+
+// Controller registration structure
+typedef struct ControllerCallbacks {
+    GameStartFunc onGameStart;
+    RoundStartFunc onRoundStart;
+    ReceiveEventFunc onReceiveEvent;
+    RetrieveDecisionFunc onRetrieveDecision;
+    GetNameFunc getName;
+    void* userData; // User data passed to callbacks
+} ControllerCallbacks;
+
+// Controller manager functions
+char** GetAvailableControllers(size_t* count);
+int RegisterController(const char* name, ControllerCallbacks callbacks);
+PlayerController* CreateController(const char* name);
+
+/**
+* Destructors
+*/
+
+// Removing from External Controller Table
+int UnregisterController(const char* name);
+// Free Controller
+void DestroyController(PlayerController* controller);
+// Free Game Settings
+void FreeGameSettings(GameSettings* settings);
+// Free entire list
+void FreeControllerList(char** list, size_t count);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/controllers/controllermanager.cc
+++ b/src/controllers/controllermanager.cc
@@ -35,4 +35,12 @@ bool ControllerManager::RegisterController(newControllerInst newFunc,
   return true;
 }
 
+bool ControllerManager::UnregisterController(const std::string& name) {
+  if (available_controllers_.contains(name)) {
+    available_controllers_.erase(name);
+    return true;
+  }
+  return false;
+}
+
 }  // namespace mahjong

--- a/src/controllers/controllermanager.h
+++ b/src/controllers/controllermanager.h
@@ -21,6 +21,7 @@ class ControllerManager {
   std::unique_ptr<mahjong::PlayerController> NewController(
       const std::string& controller);
   bool RegisterController(newControllerInst newFunc, const std::string& Name);
+  bool UnregisterController(const std::string& Name);
 
  private:
   std::map<std::string, newControllerInst> available_controllers_;


### PR DESCRIPTION
- Attempted C ABI layer. Can confirm builds and symbols look good, but need to attempt integration down the line
- Added the ability to unregister controllers. The idea behind this is in the context of using libmahjong within a continuously running service, it might be useful to be able to remove previously used external controllers. I guess in practice we will probably just hook up a generalized "Network" player controller? But I don't think it's a bad thing to have
- Tried to get the nix dev shell to work with clang (and in extension, the pipelines to build with clang). This is apparently a known hard problem due to some weird interaction between the clang and clang tools packages. I don't have it working 100%, it seems to build ok when running `nix build .#clang` but not when you're in a dev shell. Will continue to investigate



And due to the clang issues I haven't been able to run clang-tidy on this (oof)