### PR TITLE
[Nix Support] Better VS Code Experience

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,13 @@
           ninja
         ];
 
+        llvmPackage = pkgs.llvmPackages_20;
+
+        # Override the existing gtest package to use clang
+        clangGtest = pkgs.gtest.override {
+          stdenv = llvmPackage.stdenv;
+        };
+
         commonAttrs = {
           pname = "libmahjong";
           version = "0.1.0";
@@ -38,15 +45,14 @@
           };
         };
 
-        llvmPackage = pkgs.llvmPackages_20;
-
         clangNativeBuildInputs = buildPackages ++ (with llvmPackage; [
           clang-tools  # Add clang-tools which includes clang-tidy
           libcxx
           clang
-        ]) ++ (with pkgs; [
-          gtest
-        ]);
+        ]) ++ [
+          clangGtest      # Use our clang-built GTest instead of pkgs.gtest
+          clangGtest.dev  # Include the development headers
+        ];
       in
       {
         devShells.default = pkgs.mkShell.override { stdenv = llvmPackage.stdenv; } {
@@ -59,10 +65,13 @@
             echo "{" > .vscode/settings.json
             echo '  "nixEnvSelector.nixFile": "''${workspaceFolder}/shell.nix",' >> .vscode/settings.json
             echo "  \"cmake.cmakePath\": \"${pkgs.cmake}/bin/cmake\"," >> .vscode/settings.json
-            echo "  \"cmake.configureArgs\": [\"-DGTEST_LINKED_AS_SHARED_LIBRARY=1\",\"-DGTEST_MAIN_LIBRARY=${pkgs.gtest}/lib/libgtest_main.so\", \"-DGTEST_LIBRARY=${pkgs.gtest}/lib/libgtest.so\", \"-DGTEST_INCLUDE_DIR=${pkgs.gtest}/include\"]," >> .vscode/settings.json
+            echo "  \"cmake.configureArgs\": [\"-DGTEST_LINKED_AS_SHARED_LIBRARY=1\",\"-DGTEST_MAIN_LIBRARY=${clangGtest}/lib/libgtest_main.so\", \"-DGTEST_LIBRARY=${clangGtest}/lib/libgtest.so\", \"-DGTEST_INCLUDE_DIR=${clangGtest.dev}/include\"]," >> .vscode/settings.json
             echo "  \"cmake.configureEnvironment\": {\"CMAKE_MAKE_PROGRAM\": \"${pkgs.ninja}/bin/ninja\"}," >> .vscode/settings.json
-            echo "  \"C_Cpp.default.includePath\": [\"${pkgs.gtest}/include\"]" >> .vscode/settings.json
+            echo "  \"C_Cpp.default.includePath\": [\"${clangGtest.dev}/include\"]," >> .vscode/settings.json
+            echo "  \"cmake.ctestPath\": \"${pkgs.cmake}/bin/ctest\"" >> .vscode/settings.json
             echo "}" >> .vscode/settings.json
+
+            rm -f build/CMakeCache.txt && cmake -S . -B build -G Ninja
           '';
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,17 @@
           nativeBuildInputs = clangNativeBuildInputs;
 
           hardeningDisable = [ "all" ];
+
+          shellHook = ''
+            mkdir -p .vscode
+            echo "{" > .vscode/settings.json
+            echo '  "nixEnvSelector.nixFile": "''${workspaceFolder}/shell.nix",' >> .vscode/settings.json
+            echo "  \"cmake.cmakePath\": \"${pkgs.cmake}/bin/cmake\"," >> .vscode/settings.json
+            echo "  \"cmake.configureArgs\": [\"-DGTEST_LINKED_AS_SHARED_LIBRARY=1\",\"-DGTEST_MAIN_LIBRARY=${pkgs.gtest}/lib/libgtest_main.so\", \"-DGTEST_LIBRARY=${pkgs.gtest}/lib/libgtest.so\", \"-DGTEST_INCLUDE_DIR=${pkgs.gtest}/include\"]," >> .vscode/settings.json
+            echo "  \"cmake.configureEnvironment\": {\"CMAKE_MAKE_PROGRAM\": \"${pkgs.ninja}/bin/ninja\"}," >> .vscode/settings.json
+            echo "  \"C_Cpp.default.includePath\": [\"${pkgs.gtest}/include\"]" >> .vscode/settings.json
+            echo "}" >> .vscode/settings.json
+          '';
         };
 
         packages = rec {

--- a/flake.nix
+++ b/flake.nix
@@ -49,29 +49,33 @@
           clang-tools  # Add clang-tools which includes clang-tidy
           libcxx
           clang
-        ]) ++ [
+          lldb         # Use LLDB for debugging instead of GDB
+        ]) ++ (with pkgs; [
           clangGtest      # Use our clang-built GTest instead of pkgs.gtest
           clangGtest.dev  # Include the development headers
-        ];
+        ]);
       in
       {
         devShells.default = pkgs.mkShell.override { stdenv = llvmPackage.stdenv; } {
           nativeBuildInputs = clangNativeBuildInputs;
 
+          # Disable all hardening
           hardeningDisable = [ "all" ];
-
+          
           shellHook = ''
             mkdir -p .vscode
             echo "{" > .vscode/settings.json
             echo '  "nixEnvSelector.nixFile": "''${workspaceFolder}/shell.nix",' >> .vscode/settings.json
             echo "  \"cmake.cmakePath\": \"${pkgs.cmake}/bin/cmake\"," >> .vscode/settings.json
-            echo "  \"cmake.configureArgs\": [\"-DGTEST_LINKED_AS_SHARED_LIBRARY=1\",\"-DGTEST_MAIN_LIBRARY=${clangGtest}/lib/libgtest_main.so\", \"-DGTEST_LIBRARY=${clangGtest}/lib/libgtest.so\", \"-DGTEST_INCLUDE_DIR=${clangGtest.dev}/include\"]," >> .vscode/settings.json
-            echo "  \"cmake.configureEnvironment\": {\"CMAKE_MAKE_PROGRAM\": \"${pkgs.ninja}/bin/ninja\"}," >> .vscode/settings.json
-            echo "  \"C_Cpp.default.includePath\": [\"${clangGtest.dev}/include\"]," >> .vscode/settings.json
-            echo "  \"cmake.ctestPath\": \"${pkgs.cmake}/bin/ctest\"" >> .vscode/settings.json
+            echo "  \"cmake.ctestPath\": \"${pkgs.cmake}/bin/ctest\"," >> .vscode/settings.json
+            echo "  \"cmake.skipConfigureIfCachePresent\": true," >> .vscode/settings.json
+            echo "  \"cmake.configureOnOpen\": false," >> .vscode/settings.json
+            echo "  \"cmake.configureOnEdit\": false," >> .vscode/settings.json
             echo "}" >> .vscode/settings.json
 
-            rm -f build/CMakeCache.txt && cmake -S . -B build -G Ninja
+            ${pkgs.cmake}/bin/cmake -S . -B build -G Ninja \
+              -Dlibmahjong_build_tests=ON \
+              -DCMAKE_CXX_FLAGS="-O1 -g -I${clangGtest.dev}/include -I${llvmPackage.libcxx}/include/c++/v1"
           '';
         };
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  flake = (builtins.getFlake (toString ./.));
+  devShell = flake.devShells.${pkgs.system}.default;
+in
+pkgs.mkShell {
+  buildInputs = devShell.buildInputs or [];
+}


### PR DESCRIPTION
This PR configures some of the vs code options (in addition to cmake options) to support a better in-vscode experiences
- All include paths now work as expected
- Cmake no longer attempts to configure it automatically, instead the nix flake takes care of it and then vs code will use it
- Debug runs still aren't directly working, but things are now in place enough for me to use tools like lldb directly with ease