### PR TITLE
Fix nullptr on state defs in tests

### DIFF
--- a/tests/setup.test.cc
+++ b/tests/setup.test.cc
@@ -27,8 +27,7 @@ TEST(Setup, PrevalentWind) {
 }
 
 TEST(Setup, DoraIndicator) {
-  std::unique_ptr<GameState> state;
-  const PlayerControllerFake bot;
+  std::unique_ptr<GameState> state = std::make_unique<GameState>();
   for (int i = 0; i < 4; i++) {
     state->players[i].controller = std::make_unique<PlayerControllerFake>();
   }
@@ -37,7 +36,7 @@ TEST(Setup, DoraIndicator) {
 }
 
 TEST(Setup, Dealing) {
-  std::unique_ptr<GameState> state;
+  std::unique_ptr<GameState> state = std::make_unique<GameState>();
   for (int i = 0; i < 4; i++) {
     state->players[i].controller = std::make_unique<PlayerControllerFake>();
   }


### PR DESCRIPTION
Setup.DoraIndicator and Setup.Dealing both had uninitialized state definitions, leading to the segfaults.

Fixed up the two assignments and the tests passed :)