### PR TITLE
Add API function and validation of game controllers

### DIFF
--- a/src/api/gamestate.cc
+++ b/src/api/gamestate.cc
@@ -1,12 +1,12 @@
-#include <vector>
-#include <memory>
+#include "gamestate.h"
 #include <algorithm>
+#include <memory>
 #include <new>
+#include <vector>
 #include "statefunctions/statecontroller.h"
+#include "types.h"
 #include "types/piecetype.h"
 #include "types/statefunction.h"
-#include "types.h"
-#include "gamestate.h"
 
 namespace api {
 
@@ -53,7 +53,7 @@ CStateFunctionType ConvertStateFunctionType(mahjong::StateFunctionType func) {
     case mahjong::StateFunctionType::kGameEnd:
       return kGameEnd;
   }
-  
+
   // This should never be reached (unless we forget to add a new state function)
   return kError;
 }
@@ -85,8 +85,22 @@ void ExitGame(int game) {
   mahjong::ExitGame(game);
 }
 
+bool IsValidGameController(const char* controller) {
+  return mahjong::ControllerManager::Instance()
+      .GetAvailableControllersMap()
+      .contains(controller);
+}
+
 mahjong::GameState* InitGameState(const CGameSettings* settings) {
   const mahjong::GameSettings cpp_settings = convertGameSettings(settings);
+  // Check controllers ahead of time as C++ throws will not be handled correctly by
+  // all library consumers (rust)
+  for (const auto& controller : cpp_settings.seatControllers) {
+    if (!IsValidGameController(controller.c_str())) {
+      return nullptr;
+    }
+  }
+
   std::unique_ptr<mahjong::GameState> state =
       mahjong::InitGameState(cpp_settings);
   return state.release();
@@ -100,11 +114,11 @@ mahjong::GameState* AdvanceGameState(mahjong::GameState* state) {
 
 CObservedGameState ObserveGameState(mahjong::GameState* state) {
   CObservedGameState observed = {};
-  
+
   if (!state) {
     return observed;
   }
-  
+
   // Straightforward copies
   observed.currentPlayer = state->currentPlayer;
   observed.turnNum = state->turnNum;
@@ -116,22 +130,22 @@ CObservedGameState ObserveGameState(mahjong::GameState* state) {
   observed.concealedKan = state->concealedKan;
   observed.seed = state->seed;
   observed.pendingPiece = static_cast<CPiece>(state->pendingPiece.toUint8_t());
-  
+
   // State function enums
   observed.prevState = ConvertStateFunctionType(state->prevState);
   observed.currState = ConvertStateFunctionType(state->currState);
   observed.nextState = ConvertStateFunctionType(state->nextState);
-  
+
   // Player data
   for (int i = 0; i < 4; i++) {
     observed.scores[i] = state->scores[i];
     observed.points[i] = state->players[i].points;
     observed.hasRonned[i] = state->hasRonned[i];
-    
+
     // Convert Hand to CHand
     const auto& cpp_hand = state->hands[i];
     CHand& c_hand = observed.hands[i];
-    
+
     // Live pieces
     const int live_piece_count = static_cast<int>(cpp_hand.live.size());
     c_hand.livePieceCount = std::min(live_piece_count, kMaxLiveHandSize);
@@ -144,9 +158,10 @@ CObservedGameState ObserveGameState(mahjong::GameState* state) {
     c_hand.meldCount = std::min(meld_count, kMaxMeldsPerHand);
     for (int j = 0; j < c_hand.meldCount; j++) {
       c_hand.melds[j].type = static_cast<CMeldType>(cpp_hand.melds[j].type);
-      c_hand.melds[j].start = static_cast<CPiece>(cpp_hand.melds[j].start.toUint8_t());
+      c_hand.melds[j].start =
+          static_cast<CPiece>(cpp_hand.melds[j].start.toUint8_t());
     }
-    
+
     // Discards
     const auto& discards = cpp_hand.discards;
     const int discards_size = static_cast<int>(discards.size());
@@ -154,14 +169,14 @@ CObservedGameState ObserveGameState(mahjong::GameState* state) {
     for (auto j = 0; j < c_hand.discardCount; j++) {
       c_hand.discards[j] = static_cast<CPiece>(discards[j].toUint8_t());
     }
-    
+
     // Hand properties
     c_hand.open = cpp_hand.open;
     c_hand.riichi = cpp_hand.riichi;
     c_hand.riichiPieceDiscard = static_cast<int>(cpp_hand.riichiPieceDiscard);
     c_hand.riichiRound = cpp_hand.riichiRound;
   }
-  
+
   return observed;
 }
 

--- a/src/api/gamestate.cc
+++ b/src/api/gamestate.cc
@@ -1,12 +1,12 @@
-#include "gamestate.h"
-#include <algorithm>
-#include <memory>
-#include <new>
 #include <vector>
+#include <memory>
+#include <algorithm>
+#include <new>
 #include "statefunctions/statecontroller.h"
-#include "types.h"
 #include "types/piecetype.h"
 #include "types/statefunction.h"
+#include "types.h"
+#include "gamestate.h"
 
 namespace api {
 

--- a/src/api/gamestate.h
+++ b/src/api/gamestate.h
@@ -9,6 +9,7 @@ extern "C" {
 
 int StartGame(const CGameSettings* settings, bool async);
 void ExitGame(int game);
+bool IsValidGameController(const char* controller);
 mahjong::GameState* InitGameState(const CGameSettings* settings);
 mahjong::GameState* AdvanceGameState(mahjong::GameState* state);
 CObservedGameState ObserveGameState(mahjong::GameState* state);

--- a/src/controllers/controllermanager.h
+++ b/src/controllers/controllermanager.h
@@ -17,6 +17,9 @@ class ControllerManager {
     return controller_manager;
   }
 
+  std::map<std::string, newControllerInst> GetAvailableControllersMap() {
+    return available_controllers_;
+  }
   std::vector<std::string> GetAvailableControllers();
   std::unique_ptr<mahjong::PlayerController> NewController(
       const std::string& controller);

--- a/tests/api/game_control.test.cc
+++ b/tests/api/game_control.test.cc
@@ -206,4 +206,22 @@ TEST(Api, ObserveGameStateStateFunctions) {
   api::FreeGameState(state);
 }
 
+TEST(Api, GameControllerValidation) {
+  const api::CGameSettings settings = kDefaultSettings;
+
+  // Check valid controllers
+  for (const auto& controller : settings.seat_controllers) {
+    EXPECT_TRUE(api::IsValidGameController(controller));
+  }
+
+  // Check invalid controller
+  EXPECT_FALSE(api::IsValidGameController("InvalidController"));
+
+  // If an invalid controller is used, InitGameState should return nullptr
+  api::CGameSettings invalid_settings = settings;
+  invalid_settings.seat_controllers[0] = "InvalidController";
+  mahjong::GameState* state = api::InitGameState(&invalid_settings);
+  EXPECT_EQ(state, nullptr);
+}
+
 }  // namespace


### PR DESCRIPTION
Right now, if you pass the name of a controller that doesn't exist, it will throw an exception (reasonable)

However, when consuming via things like rust, these exceptions can't be caught in any way and this leads to a program abort. To help address this, the API needed some defense as well as helper functionality around this validation step. This PR introduces an exposed function so that downstream libraries and provide a means to validate the controllers ahead of time as well as defense against this abort scenario entirely.

I'm weary of checking the same stuff too many times at too many layers, but the check on InitGameState is a hard requirement imo to avoid the abort scenario, and it seems like it would be nice to check ahead of time to deal with less mysterious nullptrs.