### PR TITLE
Fix breakdownHand to fix wind and dragon pon tests

### DIFF
--- a/src/analysis/hands.cc
+++ b/src/analysis/hands.cc
@@ -981,22 +981,18 @@ int isTwicePureDoubleChi(const GameState& state, int player,
   if (state.hands.at(player).open) {
     return 0;
   }
-  int twice = 0;
+  int pairs = 0;
   for (size_t i = 0; i < branch.size(); i++) {
     if (branch.at(i)->type != Node::kChiSet) {
       continue;
     }
-    for (size_t j = 0; j < branch.size(); j++) {
+    for (size_t j = i + 1; j < branch.size(); j++) {
       if (i == j) {
-        continue;
-      }
-      if (branch.at(i)->type == branch[j]->type &&
-          branch.at(i)->start == branch[j]->start) {
-        twice++;
+        pairs++;
       }
     }
   }
-  if (twice == 2) {
+  if (pairs == 2) {
     return 3;
   }
   return 0;

--- a/src/analysis/hands.cc
+++ b/src/analysis/hands.cc
@@ -987,7 +987,8 @@ int isTwicePureDoubleChi(const GameState& state, int player,
       continue;
     }
     for (size_t j = i + 1; j < branch.size(); j++) {
-      if (i == j) {
+      if (branch.at(j)->type == Node::kChiSet &&
+          branch.at(i)->start == branch.at(j)->start) {
         pairs++;
       }
     }

--- a/src/analysis/handtree.cc
+++ b/src/analysis/handtree.cc
@@ -206,17 +206,29 @@ void resetCounts(Breakdown* b, const Node* target) {
 
 // NOLINTNEXTLINE(misc-no-recursion)
 void driver(Breakdown* b) {
+  // - Always process the tile into the fewest groupings first
+  // - If a tile has only one way to be grouped, use it
+  // - If a tile has multiple ways, try each possibility
+  // - Continue until all tiles are in groups
+
+  // While there are ungrouped pieces
   for (updatePossibilities(b); !b->pieces.empty(); updatePossibilities(b)) {
+    // Get the piece with minimum possibilities
     const int piece_pos = getNextPiece(b);
 
     if (b->possibilities[piece_pos] == 0) {
+      // No valid grouping possible, single piece
       breakdownSingle(b, piece_pos);
       continue;
     }
+
     if (b->possibilities[piece_pos] == 1) {
+      // One way to be grouped, use it
       if (anyPossibleChi(b->counts, b->pieces[piece_pos])) {
+        // A chi is possible, determine how it can be a part of one
         for (int i = 0; i < 3; i++) {
           const Piece chi_start = b->pieces[piece_pos] - i;
+          // Check if we can start a chi with this piece
           if (possibleChiForward(b->counts, chi_start)) {
             // Find the position of chi_start in the pieces vector
             auto it = std::find(b->pieces.begin(), b->pieces.end(), chi_start);
@@ -230,66 +242,71 @@ void driver(Breakdown* b) {
         continue;
       }
       if (possiblePon(b->counts, b->pieces[piece_pos])) {
+        // A pon is possible
         breakdownPon(b, piece_pos);
         continue;
       }
       if (possiblePair(b->counts, b->pieces[piece_pos])) {
+        // A pair is possible
         breakdownPair(b, piece_pos);
         continue;
       }
     }
     if (b->possibilities[piece_pos] >= 2) {
+      // Tile has multiple groups, we need to check branches
+
+      // Save current position in tree so we can backtrack
       auto* current = b->currentNode;
       int branch = 0;
+
       if (possibleChiForward(b->counts, b->pieces[piece_pos] - 0)) {
+        // Can be the begining of a chi
         branch++;
         breakdownForwardChi(b, piece_pos);
         driver(b);
         resetCounts(b, current);
       }
+
       if (possibleChiForward(b->counts, b->pieces[piece_pos] - 1)) {
+        // Can be the middle of a chi
         branch++;
-        // Find position of the piece that would start this chi
         const Piece chi_start = b->pieces[piece_pos] - 1;
         auto it = std::find(b->pieces.begin(), b->pieces.end(), chi_start);
         if (it != b->pieces.end()) {
           const int chi_start_pos = std::distance(b->pieces.begin(), it);
           breakdownForwardChi(b, chi_start_pos);
           driver(b);
-          if (branch < 2) {
-            resetCounts(b, current);
-          }
+          resetCounts(b, current);
         }
       }
+
       if (possibleChiForward(b->counts, b->pieces[piece_pos] - 2)) {
+        // Can be the end of a chi
         branch++;
-        // Find position of the piece that would start this chi
         const Piece chi_start = b->pieces[piece_pos] - 2;
         auto it = std::find(b->pieces.begin(), b->pieces.end(), chi_start);
         if (it != b->pieces.end()) {
           const int chi_start_pos = std::distance(b->pieces.begin(), it);
           breakdownForwardChi(b, chi_start_pos);
           driver(b);
-          if (branch < 2) {
-            resetCounts(b, current);
-          }
+          resetCounts(b, current);
         }
       }
+
       if (possiblePon(b->counts, b->pieces[piece_pos])) {
+        // Can be a pon
         branch++;
         breakdownPon(b, piece_pos);
         driver(b);
-        if (branch < 2) {
-          resetCounts(b, current);
-        }
+        resetCounts(b, current);
       }
+
       if (possiblePair(b->counts, b->pieces[piece_pos])) {
+        // Can be a pair
         branch++;
         breakdownPair(b, piece_pos);
         driver(b);
-        if (branch < 2) {
-          resetCounts(b, current);
-        }
+        resetCounts(b, current);
       }
     }
   }

--- a/src/analysis/handtree.cc
+++ b/src/analysis/handtree.cc
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <fstream>  // IWYU pragma: keep
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -205,8 +206,9 @@ void resetCounts(Breakdown* b, const Node* target) {
 
 // NOLINTNEXTLINE(misc-no-recursion)
 void driver(Breakdown* b) {
-  for (updatePossibilities(b); b->pieces.empty(); updatePossibilities(b)) {
+  for (updatePossibilities(b); !b->pieces.empty(); updatePossibilities(b)) {
     const int piece_pos = getNextPiece(b);
+
     if (b->possibilities[piece_pos] == 0) {
       breakdownSingle(b, piece_pos);
       continue;
@@ -214,8 +216,14 @@ void driver(Breakdown* b) {
     if (b->possibilities[piece_pos] == 1) {
       if (anyPossibleChi(b->counts, b->pieces[piece_pos])) {
         for (int i = 0; i < 3; i++) {
-          if (possibleChiForward(b->counts, b->pieces[piece_pos] - i)) {
-            breakdownForwardChi(b, piece_pos - i);
+          const Piece chi_start = b->pieces[piece_pos] - i;
+          if (possibleChiForward(b->counts, chi_start)) {
+            // Find the position of chi_start in the pieces vector
+            auto it = std::find(b->pieces.begin(), b->pieces.end(), chi_start);
+            if (it != b->pieces.end()) {
+              const int chi_start_pos = std::distance(b->pieces.begin(), it);
+              breakdownForwardChi(b, chi_start_pos);
+            }
             break;
           }
         }
@@ -230,47 +238,58 @@ void driver(Breakdown* b) {
         continue;
       }
     }
-    if (b->possibilities[piece_pos] == 2) {
+    if (b->possibilities[piece_pos] >= 2) {
       auto* current = b->currentNode;
       int branch = 0;
       if (possibleChiForward(b->counts, b->pieces[piece_pos] - 0)) {
         branch++;
-        breakdownForwardChi(b, piece_pos - 0);
+        // piece_pos is already the correct position for a chi starting at this piece
+        breakdownForwardChi(b, piece_pos);
         driver(b);
         resetCounts(b, current);
       }
       if (possibleChiForward(b->counts, b->pieces[piece_pos] - 1)) {
         branch++;
-        breakdownForwardChi(b, piece_pos - 1);
-        if (branch == 2) {
-          continue;
+        // Find position of the piece that would start this chi
+        const Piece chi_start = b->pieces[piece_pos] - 1;
+        auto it = std::find(b->pieces.begin(), b->pieces.end(), chi_start);
+        if (it != b->pieces.end()) {
+          const int chi_start_pos = std::distance(b->pieces.begin(), it);
+          breakdownForwardChi(b, chi_start_pos);
+          driver(b);
+          if (branch < 2) {
+            resetCounts(b, current);
+          }
         }
-        driver(b);
-        resetCounts(b, current);
       }
       if (possibleChiForward(b->counts, b->pieces[piece_pos] - 2)) {
         branch++;
-        breakdownForwardChi(b, piece_pos - 2);
-        if (branch == 2) {
-          continue;
+        // Find position of the piece that would start this chi
+        const Piece chi_start = b->pieces[piece_pos] - 2;
+        auto it = std::find(b->pieces.begin(), b->pieces.end(), chi_start);
+        if (it != b->pieces.end()) {
+          const int chi_start_pos = std::distance(b->pieces.begin(), it);
+          breakdownForwardChi(b, chi_start_pos);
+          driver(b);
+          if (branch < 2) {
+            resetCounts(b, current);
+          }
         }
-        driver(b);
-        resetCounts(b, current);
       }
       if (possiblePon(b->counts, b->pieces[piece_pos])) {
         branch++;
         breakdownPon(b, piece_pos);
-        if (branch == 2) {
-          continue;
-        }
         driver(b);
-        resetCounts(b, current);
+        if (branch < 2) {
+          resetCounts(b, current);
+        }
       }
       if (possiblePair(b->counts, b->pieces[piece_pos])) {
         branch++;
         breakdownPair(b, piece_pos);
-        if (branch == 2) {
-          continue;
+        driver(b);
+        if (branch < 2) {
+          resetCounts(b, current);
         }
       }
     }
@@ -280,6 +299,7 @@ void driver(Breakdown* b) {
 }  // namespace
 
 std::unique_ptr<Node> breakdownHand(const std::vector<Piece>& pieces) {
+
   Breakdown b;
   b.rootNode = std::make_unique<Node>(b.id++,                     // id
                                       Node::kRoot,                // type

--- a/src/analysis/handtree.cc
+++ b/src/analysis/handtree.cc
@@ -257,56 +257,105 @@ void driver(Breakdown* b) {
 
       // Save current position in tree so we can backtrack
       auto* current = b->currentNode;
-      int branch = 0;
 
-      if (possibleChiForward(b->counts, b->pieces[piece_pos] - 0)) {
-        // Can be the begining of a chi
-        branch++;
-        breakdownForwardChi(b, piece_pos);
-        driver(b);
-        resetCounts(b, current);
-      }
+      // Check grouping possibilities
+      const bool can_chi_start =
+          possibleChiForward(b->counts, b->pieces[piece_pos] - 0);
 
+      bool can_chi_middle = false;
+      int chi_middle_pos = -1;
       if (possibleChiForward(b->counts, b->pieces[piece_pos] - 1)) {
-        // Can be the middle of a chi
-        branch++;
         const Piece chi_start = b->pieces[piece_pos] - 1;
         auto it = std::find(b->pieces.begin(), b->pieces.end(), chi_start);
         if (it != b->pieces.end()) {
-          const int chi_start_pos = std::distance(b->pieces.begin(), it);
-          breakdownForwardChi(b, chi_start_pos);
-          driver(b);
-          resetCounts(b, current);
+          can_chi_middle = true;
+          chi_middle_pos = std::distance(b->pieces.begin(), it);
         }
       }
 
+      bool can_chi_end = false;
+      int chi_end_pos = -1;
       if (possibleChiForward(b->counts, b->pieces[piece_pos] - 2)) {
-        // Can be the end of a chi
-        branch++;
         const Piece chi_start = b->pieces[piece_pos] - 2;
         auto it = std::find(b->pieces.begin(), b->pieces.end(), chi_start);
         if (it != b->pieces.end()) {
-          const int chi_start_pos = std::distance(b->pieces.begin(), it);
-          breakdownForwardChi(b, chi_start_pos);
-          driver(b);
+          can_chi_end = true;
+          chi_end_pos = std::distance(b->pieces.begin(), it);
+        }
+      }
+
+      const bool can_pon = possiblePon(b->counts, b->pieces[piece_pos]);
+      const bool can_pair = possiblePair(b->counts, b->pieces[piece_pos]);
+
+      // Count total branches that will actually execute
+      int total_branches = 0;
+      if (can_chi_start) {
+        total_branches++;
+      }
+      if (can_chi_middle) {
+        total_branches++;
+      }
+      if (can_chi_end) {
+        total_branches++;
+      }
+      if (can_pon) {
+        total_branches++;
+      }
+      if (can_pair) {
+        total_branches++;
+      }
+
+      // Execute branches
+      int current_branch = 0;
+
+      if (can_chi_start) {
+        // Can be the beginning of a chi
+        current_branch++;
+        breakdownForwardChi(b, piece_pos);
+        driver(b);
+        if (current_branch < total_branches) {
           resetCounts(b, current);
         }
       }
 
-      if (possiblePon(b->counts, b->pieces[piece_pos])) {
-        // Can be a pon
-        branch++;
-        breakdownPon(b, piece_pos);
+      if (can_chi_middle) {
+        // Can be the middle of a chi
+        current_branch++;
+        breakdownForwardChi(b, chi_middle_pos);
         driver(b);
-        resetCounts(b, current);
+        if (current_branch < total_branches) {
+          resetCounts(b, current);
+        }
       }
 
-      if (possiblePair(b->counts, b->pieces[piece_pos])) {
+      if (can_chi_end) {
+        // Can be the end of a chi
+        current_branch++;
+        breakdownForwardChi(b, chi_end_pos);
+        driver(b);
+        if (current_branch < total_branches) {
+          resetCounts(b, current);
+        }
+      }
+
+      if (can_pon) {
+        // Can be a pon
+        current_branch++;
+        breakdownPon(b, piece_pos);
+        driver(b);
+        if (current_branch < total_branches) {
+          resetCounts(b, current);
+        }
+      }
+
+      if (can_pair) {
         // Can be a pair
-        branch++;
+        current_branch++;
         breakdownPair(b, piece_pos);
         driver(b);
-        resetCounts(b, current);
+        if (current_branch < total_branches) {
+          resetCounts(b, current);
+        }
       }
     }
   }

--- a/src/analysis/handtree.cc
+++ b/src/analysis/handtree.cc
@@ -298,7 +298,6 @@ void driver(Breakdown* b) {
 }  // namespace
 
 std::unique_ptr<Node> breakdownHand(const std::vector<Piece>& pieces) {
-
   Breakdown b;
   b.rootNode = std::make_unique<Node>(b.id++,                     // id
                                       Node::kRoot,                // type

--- a/src/analysis/handtree.cc
+++ b/src/analysis/handtree.cc
@@ -243,7 +243,6 @@ void driver(Breakdown* b) {
       int branch = 0;
       if (possibleChiForward(b->counts, b->pieces[piece_pos] - 0)) {
         branch++;
-        // piece_pos is already the correct position for a chi starting at this piece
         breakdownForwardChi(b, piece_pos);
         driver(b);
         resetCounts(b, current);

--- a/src/types/handnode.cc
+++ b/src/types/handnode.cc
@@ -71,14 +71,8 @@ bool Node::operator!=(const Node& n) const {
          leafPosInParent == n.leafPosInParent;
 }
 
-Node::~Node() {
-  if (parent != nullptr) {
-    parent->leaves.erase(parent->leaves.begin() + leafPosInParent);
-    for (size_t i = 0; i < parent->leaves.size(); i++) {
-      parent->leaves.at(i)->leafPosInParent = i;
-    }
-  }
-}
+// dont free parent, its not owned
+Node::~Node() = default;
 
 Node::ConstIterator& Node::ConstIterator::operator++() {
   if (!root_->leaves.empty()) {
@@ -185,25 +179,55 @@ std::ostream& Node::DumpAsDot(std::ostream& os) const {
 }
 
 std::vector<std::vector<const Node*>> Node::AsBranchVectors(const Node* root) {
+  if (!root) {
+    std::cerr << "ERROR: AsBranchVectors called with null root\n";
+    return {};
+  }
+
   std::vector<std::vector<const Node*>> branches;
   std::vector<const Node*> nodeloc;
   nodeloc.push_back(root);
+
   while (!nodeloc.empty()) {
-    if (!nodeloc.back()->leaves.empty()) {
-      nodeloc.push_back(nodeloc.back()->leaves[0].get());
+    if (nodeloc.empty()) {
+      std::cerr << "ERROR: AsBranchVectors nodeloc became empty unexpectedly\n";
+      break;
+    }
+
+    const Node* current = nodeloc.back();
+    if (!current) {
+      std::cerr << "ERROR: AsBranchVectors null node in nodeloc\n";
+      nodeloc.pop_back();
+      continue;
+    }
+
+    if (!current->leaves.empty()) {
+      nodeloc.push_back(current->leaves[0].get());
     } else {
       branches.push_back(nodeloc);
-      size_t next = nodeloc.back()->leafPosInParent + 1;
-      while ((nodeloc.back()->parent != nullptr) &&
-             nodeloc.back()->parent->leaves.size() <= next) {
+      size_t next = current->leafPosInParent + 1;
+
+      while ((current->parent != nullptr) &&
+             current->parent->leaves.size() <= next) {
         nodeloc.pop_back();
-        next = nodeloc.back()->leafPosInParent + 1;
+        if (nodeloc.empty()) {
+          break;
+        }
+        current = nodeloc.back();
+        next = current->leafPosInParent + 1;
       }
-      if (nodeloc.back()->parent == nullptr) {
+
+      if (nodeloc.empty() || current->parent == nullptr) {
         nodeloc.pop_back();
       } else {
         nodeloc.pop_back();
-        nodeloc.push_back(nodeloc.back()->leaves[next].get());
+        if (!nodeloc.empty() && next < nodeloc.back()->leaves.size()) {
+          nodeloc.push_back(nodeloc.back()->leaves[next].get());
+        } else {
+          std::cerr << "ERROR: AsBranchVectors next index " << next
+                    << " out of bounds\n";
+          break;
+        }
       }
     }
   }

--- a/tests/yakus/dragonpon.test.cc
+++ b/tests/yakus/dragonpon.test.cc
@@ -12,7 +12,7 @@
 
 namespace mahjong {
 
-TEST(isWindOrDragonPon, DISABLED_WhiteDragon) {
+TEST(isWindOrDragonPon, WhiteDragon) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m555z11z"));
 
@@ -27,7 +27,7 @@ TEST(isWindOrDragonPon, DISABLED_WhiteDragon) {
   FAIL();
 }
 
-TEST(isWindOrDragonPon, DISABLED_GreenDragon) {
+TEST(isWindOrDragonPon, GreenDragon) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m666z11z"));
 
@@ -42,7 +42,7 @@ TEST(isWindOrDragonPon, DISABLED_GreenDragon) {
   FAIL();
 }
 
-TEST(isWindOrDragonPon, DISABLED_RedDragon) {
+TEST(isWindOrDragonPon, RedDragon) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m777z11z"));
 
@@ -57,7 +57,7 @@ TEST(isWindOrDragonPon, DISABLED_RedDragon) {
   FAIL();
 }
 
-TEST(isWindOrDragonPon, DISABLED_Kan) {
+TEST(isWindOrDragonPon, Kan) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m7777z11z"));
 
@@ -72,7 +72,7 @@ TEST(isWindOrDragonPon, DISABLED_Kan) {
   FAIL();
 }
 
-TEST(isWindOrDragonPon, DISABLED_CanWhenOpen) {
+TEST(isWindOrDragonPon, CanWhenOpen) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m777z11z"));
   game_state.hands[0].open = true;

--- a/tests/yakus/twicepuredoublechi.test.cc
+++ b/tests/yakus/twicepuredoublechi.test.cc
@@ -12,7 +12,7 @@
 
 namespace mahjong {
 
-TEST(isTwicePureDoubleChi, DISABLED_3Han) {
+TEST(isTwicePureDoubleChi, 3Han) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("789p789p234m234m11z"));
   game_state.hands[0].open = false;

--- a/tests/yakus/windpons.test.cc
+++ b/tests/yakus/windpons.test.cc
@@ -12,23 +12,26 @@
 
 namespace mahjong {
 
-TEST(isWindOrDragonPon, DISABLED_SeatWind) {
+TEST(isWindOrDragonPon, SeatWind) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m444z55z"));
   game_state.roundNum = 1;
 
   auto root = breakdownHand(game_state.hands.at(0).live);
 
-  for (const auto& branch : Node::AsBranchVectors(root.get())) {
+  auto branches = Node::AsBranchVectors(root.get());
+
+  for (const auto& branch : branches) {
     if (mahjong::isWindOrDragonPon(game_state, 0, branch) == 1) {
       SUCCEED();
       return;
     }
   }
+
   FAIL();
 }
 
-TEST(isWindOrDragonPon, DISABLED_SeatWindKan) {
+TEST(isWindOrDragonPon, SeatWindKan) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m4444z55z"));
   game_state.roundNum = 1;
@@ -44,7 +47,7 @@ TEST(isWindOrDragonPon, DISABLED_SeatWindKan) {
   FAIL();
 }
 
-TEST(isWindOrDragonPon, DISABLED_PrevalentWind) {
+TEST(isWindOrDragonPon, PrevalentWind) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m111z55z"));
   game_state.roundNum = 1;
@@ -60,7 +63,7 @@ TEST(isWindOrDragonPon, DISABLED_PrevalentWind) {
   FAIL();
 }
 
-TEST(isWindOrDragonPon, DISABLED_PrevalentWindKan) {
+TEST(isWindOrDragonPon, PrevalentWindKan) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m1111z55z"));
   game_state.roundNum = 1;
@@ -76,7 +79,7 @@ TEST(isWindOrDragonPon, DISABLED_PrevalentWindKan) {
   FAIL();
 }
 
-TEST(isWindOrDragonPon, DISABLED_Dealer2Han) {
+TEST(isWindOrDragonPon, Dealer2Han) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m111z55z"));
   game_state.roundNum = 0;
@@ -92,7 +95,7 @@ TEST(isWindOrDragonPon, DISABLED_Dealer2Han) {
   FAIL();
 }
 
-TEST(isWindOrDragonPon, DISABLED_Dealer2HanKan) {
+TEST(isWindOrDragonPon, Dealer2HanKan) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m1111z55z"));
   game_state.roundNum = 0;


### PR DESCRIPTION
Fixed up some breakdownHand logic based on findings when investigating wind and dragon pon tests. Also made AsBranchVector a bit more robust against failure cases, which I was also hitting

There's a chance this has fixed more tests than just these, which I can investigate before checking in if preferred