### PR TITLE
Handnode rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ Testing/
 vgcore.*
 callgrind.out.*
 *.svg
+.cache

--- a/src/analysis/hands.cc
+++ b/src/analysis/hands.cc
@@ -715,7 +715,7 @@ int isOutsideHand(const GameState& state, int player,
   if (!chi) {
     return 0;
   }
-  return state.hands.at(state.currentPlayer).open ? 1 : 2;
+  return state.hands.at(player).open ? 1 : 2;
 }
 
 int isAfterAKan(const GameState& state, int player,
@@ -836,17 +836,22 @@ int isThreeKans(const GameState& state, int player,
 
 int isAllPons(const GameState& state, int player,
               const std::vector<const mahjong::Node*>& branch) {
+  int pons = 0;
   for (const auto& node : branch) {
-    if (node->type() != Node::kPonSet) {
-      return 0;
+    if (node->type() == Node::kPonSet) {
+      pons++;
     }
   }
   for (const auto& meld : state.hands.at(player).melds) {
-    if (meld.type == Meld::kChi) {
-      return 0;
+    if (meld.type == Meld::kKan || meld.type == Meld::kPon ||
+        meld.type == Meld::kConcealedKan) {
+      pons++;
     }
   }
-  return 2;
+  if (pons == 4) {
+    return 2;
+  }
+  return 0;
 }
 
 int isHalfFlush(const GameState& state, int player,

--- a/src/analysis/hands.cc
+++ b/src/analysis/hands.cc
@@ -31,7 +31,7 @@ int countSingles(const std::vector<Piece>& hand) {
   for (const auto& branch : Node::AsBranchVectors(root.get())) {
     int singles = 0;
     for (const auto& node : branch) {
-      if (node->type == Node::kSingle) {
+      if (node->type() == Node::kSingle) {
         singles++;
       }
     }
@@ -95,7 +95,7 @@ Score scoreHand(const GameState& state, int player) {
   for (const auto& branch : Node::AsBranchVectors(root.get())) {
     Score branchscore;
     for (const auto& node : branch) {
-      if (node->type == Node::kSingle) {
+      if (node->type() == Node::kSingle) {
         continue;
       }
     }
@@ -234,8 +234,8 @@ int getFu(const GameState& state, int player,
     }
   }
   for (const auto& node : branch) {
-    if (node->type == Node::kPonSet) {
-      if (!node->start.isHonor() && !node->start.isTerminal()) {
+    if (node->type() == Node::kPonSet) {
+      if (!node->start().isHonor() && !node->start().isTerminal()) {
         fu += open ? kSimplepon : kCsimplepon;
       } else {
         fu += open ? kTermHonorpon : kCtermHonorpon;
@@ -244,29 +244,29 @@ int getFu(const GameState& state, int player,
     if (open) {
       continue;
     }
-    if (node->type == Node::kPair) {
-      if (node->start.isHonor()) {
-        if (node->start == kGreenDragon || node->start == kRedDragon ||
-            node->start == kWhiteDragon ||
-            node->start == (state.roundNum > 3 ? kSouthWind : kEastWind)) {
+    if (node->type() == Node::kPair) {
+      if (node->start().isHonor()) {
+        if (node->start() == kGreenDragon || node->start() == kRedDragon ||
+            node->start() == kWhiteDragon ||
+            node->start() == (state.roundNum > 3 ? kSouthWind : kEastWind)) {
           fu += kDragonseatprevalentwind;
         }
       }
-      if (node->start == state.pendingPiece) {
+      if (node->start() == state.pendingPiece) {
         fu += kEdgeclosedpairwait;
       }
     }
-    if (node->type == Node::kChiSet) {
-      if (node->start + 1 == state.pendingPiece) {
+    if (node->type() == Node::kChiSet) {
+      if (node->start() + 1 == state.pendingPiece) {
         fu += kEdgeclosedpairwait;
       }
-      if (node->start.getPieceNum() == 1 &&
+      if (node->start().getPieceNum() == 1 &&
           state.pendingPiece.getPieceNum() == kLowedgewait &&
-          node->start.getSuit() == state.pendingPiece.getSuit()) {
+          node->start().getSuit() == state.pendingPiece.getSuit()) {
         fu += kEdgeclosedpairwait;
       }
-      if (node->start.getPieceNum() == kHighedgewait &&
-          state.pendingPiece == node->start) {
+      if (node->start().getPieceNum() == kHighedgewait &&
+          state.pendingPiece == node->start()) {
         fu += kEdgeclosedpairwait;
       }
     }
@@ -281,18 +281,18 @@ int getFu(const GameState& state, int player,
 bool isOpenPinfu(const GameState& state, int player,
                  const std::vector<const mahjong::Node*>& branch) {
   for (const auto& node : branch) {
-    if (node->type == Node::kPonSet) {
+    if (node->type() == Node::kPonSet) {
       return false;
     }
-    if (node->type == Node::kPair) {
-      if (node->start == kRedDragon || node->start == kWhiteDragon ||
-          node->start == kGreenDragon) {
+    if (node->type() == Node::kPair) {
+      if (node->start() == kRedDragon || node->start() == kWhiteDragon ||
+          node->start() == kGreenDragon) {
         return false;
       }
-      if (node->start == kSouthWind && state.roundNum > 3) {
+      if (node->start() == kSouthWind && state.roundNum > 3) {
         return false;
       }
-      if (node->start == kEastWind && state.roundNum < 4) {
+      if (node->start() == kEastWind && state.roundNum < 4) {
         return false;
       }
     }
@@ -314,7 +314,7 @@ bool isComplete(const GameState& state, int player) {
   }
   for (const auto& branch : Node::AsBranchVectors(root.get())) {
     for (const auto& node : branch) {
-      if (node->type == Node::kSingle) {
+      if (node->type() == Node::kSingle) {
         continue;
       }
     }
@@ -481,18 +481,18 @@ int isPinfu(const GameState& state, int player,
     return 0;
   }
   for (const auto& node : branch) {
-    if (node->type == Node::kPonSet) {
+    if (node->type() == Node::kPonSet) {
       return 0;
     }
-    if (node->type == Node::kPair) {
-      if (node->start == kRedDragon || node->start == kWhiteDragon ||
-          node->start == kGreenDragon) {
+    if (node->type() == Node::kPair) {
+      if (node->start() == kRedDragon || node->start() == kWhiteDragon ||
+          node->start() == kGreenDragon) {
         return 0;
       }
-      if (node->start == kSouthWind && state.roundNum > 3) {
+      if (node->start() == kSouthWind && state.roundNum > 3) {
         return 0;
       }
-      if (node->start == kEastWind && state.roundNum < 4) {
+      if (node->start() == kEastWind && state.roundNum < 4) {
         return 0;
       }
     }
@@ -513,15 +513,15 @@ int isPureDoubleChi(const GameState& state, int player,
     return 0;
   }
   for (size_t i = 0; i < branch.size(); i++) {
-    if (branch.at(i)->type != Node::kChiSet) {
+    if (branch.at(i)->type() != Node::kChiSet) {
       continue;
     }
     for (size_t j = 0; j < branch.size(); j++) {
       if (i == j) {
         continue;
       }
-      if (branch.at(i)->type == branch[j]->type &&
-          branch.at(i)->start == branch[j]->start) {
+      if (branch.at(i)->type() == branch[j]->type() &&
+          branch.at(i)->start() == branch[j]->start()) {
         return 1;
       }
     }
@@ -551,15 +551,15 @@ int isMixedTripleChi(const GameState& state, int player,
   std::array<bool, kPiecesinasuit> char_chi = {};
   std::array<bool, kPiecesinasuit> pin_chi = {};
   for (const auto& node : branch) {
-    if (node->type == Node::kChiSet) {
-      if (node->start.getSuit() == Piece::Type::kBambooSuit) {
-        bamboo_chi.at(node->start.getPieceNum()) = true;
+    if (node->type() == Node::kChiSet) {
+      if (node->start().getSuit() == Piece::Type::kBambooSuit) {
+        bamboo_chi.at(node->start().getPieceNum()) = true;
       }
-      if (node->start.getSuit() == Piece::Type::kCharacterSuit) {
-        char_chi.at(node->start.getPieceNum()) = true;
+      if (node->start().getSuit() == Piece::Type::kCharacterSuit) {
+        char_chi.at(node->start().getPieceNum()) = true;
       }
-      if (node->start.getSuit() == Piece::Type::kPinSuit) {
-        pin_chi.at(node->start.getPieceNum()) = true;
+      if (node->start().getSuit() == Piece::Type::kPinSuit) {
+        pin_chi.at(node->start().getPieceNum()) = true;
       }
     }
   }
@@ -593,24 +593,24 @@ int isPureStraight(const GameState& state, int player,
   std::array<bool, 3> char_chi = {};
   std::array<bool, 3> pin_chi = {};
   for (const auto& node : branch) {
-    if (node->type == Node::kChiSet) {
+    if (node->type() == Node::kChiSet) {
       int ind = 0;
-      if (node->start.getPieceNum() == kFirstchistart) {
+      if (node->start().getPieceNum() == kFirstchistart) {
         ind = 0;
-      } else if (node->start.getPieceNum() == kSecondchistart) {
+      } else if (node->start().getPieceNum() == kSecondchistart) {
         ind = 1;
-      } else if (node->start.getPieceNum() == kThirdchistart) {
+      } else if (node->start().getPieceNum() == kThirdchistart) {
         ind = 2;
       } else {
         continue;
       }
-      if (node->start.getSuit() == Piece::Type::kBambooSuit) {
+      if (node->start().getSuit() == Piece::Type::kBambooSuit) {
         bamboo_chi.at(ind) = true;
       }
-      if (node->start.getSuit() == Piece::Type::kCharacterSuit) {
+      if (node->start().getSuit() == Piece::Type::kCharacterSuit) {
         char_chi.at(ind) = true;
       }
-      if (node->start.getSuit() == Piece::Type::kPinSuit) {
+      if (node->start().getSuit() == Piece::Type::kPinSuit) {
         pin_chi.at(ind) = true;
       }
     }
@@ -661,7 +661,7 @@ int isWindOrDragonPon(const GameState& state, int player,
   for (const auto& match : matches) {
     bool is_match = false;
     for (const auto& node : branch) {
-      if (node->type == Node::kPonSet && node->start == match) {
+      if (node->type() == Node::kPonSet && node->start() == match) {
         is_match = true;
         break;
       }
@@ -687,14 +687,14 @@ int isOutsideHand(const GameState& state, int player,
   }
   bool chi = false;
   for (const auto& node : branch) {
-    if (node->type == Node::kChiSet) {
-      if (node->start.isTerminal() || (node->start + 2).isTerminal()) {
+    if (node->type() == Node::kChiSet) {
+      if (node->start().isTerminal() || (node->start() + 2).isTerminal()) {
         chi = true;
       } else {
         return 0;
       }
     } else {
-      if (!node->start.isTerminal() && !node->start.isHonor()) {
+      if (!node->start().isTerminal() && !node->start().isHonor()) {
         return 0;
       }
     }
@@ -768,15 +768,15 @@ int isTriplePon(const GameState& state, int player,
   std::array<bool, kPiecesinasuit> char_pon = {};
   std::array<bool, kPiecesinasuit> pin_pon = {};
   for (const auto& node : branch) {
-    if (node->type == Node::kPonSet) {
-      if (node->start.getSuit() == Piece::Type::kBambooSuit) {
-        bamboo_pon.at(node->start.getPieceNum() - 1) = true;
+    if (node->type() == Node::kPonSet) {
+      if (node->start().getSuit() == Piece::Type::kBambooSuit) {
+        bamboo_pon.at(node->start().getPieceNum() - 1) = true;
       }
-      if (node->start.getSuit() == Piece::Type::kCharacterSuit) {
-        char_pon.at(node->start.getPieceNum() - 1) = true;
+      if (node->start().getSuit() == Piece::Type::kCharacterSuit) {
+        char_pon.at(node->start().getPieceNum() - 1) = true;
       }
-      if (node->start.getSuit() == Piece::Type::kPinSuit) {
-        pin_pon.at(node->start.getPieceNum() - 1) = true;
+      if (node->start().getSuit() == Piece::Type::kPinSuit) {
+        pin_pon.at(node->start().getPieceNum() - 1) = true;
       }
     }
   }
@@ -805,7 +805,7 @@ int isThreeConcealedPons(const GameState& state, int player,
                          const std::vector<const mahjong::Node*>& branch) {
   int concealed_pons = 0;
   for (const auto& node : branch) {
-    if (node->type == Node::kPonSet) {
+    if (node->type() == Node::kPonSet) {
       concealed_pons++;
     }
   }
@@ -837,7 +837,7 @@ int isThreeKans(const GameState& state, int player,
 int isAllPons(const GameState& state, int player,
               const std::vector<const mahjong::Node*>& branch) {
   for (const auto& node : branch) {
-    if (node->type != Node::kPonSet) {
+    if (node->type() != Node::kPonSet) {
       return 0;
     }
   }
@@ -885,7 +885,7 @@ int isLittleThreeDragons(const GameState& state, int player,
   bool pair = false;
   int pons = 0;
   for (const auto& node : branch) {
-    switch (node->start.toUint8_t()) {
+    switch (node->start().toUint8_t()) {
       case Piece::Type::kRedDragon:
       case Piece::Type::kGreenDragon:
       case Piece::Type::kWhiteDragon:
@@ -893,7 +893,7 @@ int isLittleThreeDragons(const GameState& state, int player,
       default:
         continue;
     }
-    if (node->type != Node::kPair) {
+    if (node->type() != Node::kPair) {
       pons++;
     } else {
       if (pair) {
@@ -945,14 +945,14 @@ int isTerminalsInAllSets(const GameState& state, int player,
   }
   bool chi = false;
   for (const auto& node : branch) {
-    if (node->type == Node::kChiSet) {
-      if (node->start.isTerminal() || (node->start + 2).isTerminal()) {
+    if (node->type() == Node::kChiSet) {
+      if (node->start().isTerminal() || (node->start() + 2).isTerminal()) {
         chi = true;
       } else {
         return 0;
       }
     } else {
-      if (!node->start.isTerminal()) {
+      if (!node->start().isTerminal()) {
         return 0;
       }
     }
@@ -983,12 +983,12 @@ int isTwicePureDoubleChi(const GameState& state, int player,
   }
   int pairs = 0;
   for (size_t i = 0; i < branch.size(); i++) {
-    if (branch.at(i)->type != Node::kChiSet) {
+    if (branch.at(i)->type() != Node::kChiSet) {
       continue;
     }
     for (size_t j = i + 1; j < branch.size(); j++) {
-      if (branch.at(j)->type == Node::kChiSet &&
-          branch.at(i)->start == branch.at(j)->start) {
+      if (branch.at(j)->type() == Node::kChiSet &&
+          branch.at(i)->start() == branch.at(j)->start()) {
         pairs++;
       }
     }
@@ -1148,7 +1148,7 @@ int isFourConcealedPon(const GameState& state, int player,
   }
   int concealed_pons = 0;
   for (const auto& node : branch) {
-    if (node->type == Node::kPonSet) {
+    if (node->type() == Node::kPonSet) {
       concealed_pons++;
     }
   }
@@ -1226,7 +1226,7 @@ int isBigThreeDragons(const GameState& state, int player,
                       const std::vector<const mahjong::Node*>& branch) {
   int pons = 0;
   for (const auto& node : branch) {
-    switch (node->start.toUint8_t()) {
+    switch (node->start().toUint8_t()) {
       case Piece::Type::kRedDragon:
       case Piece::Type::kGreenDragon:
       case Piece::Type::kWhiteDragon:
@@ -1234,7 +1234,7 @@ int isBigThreeDragons(const GameState& state, int player,
       default:
         continue;
     }
-    if (node->type == Node::kPair) {
+    if (node->type() == Node::kPair) {
       return 0;
     }
     pons++;
@@ -1261,7 +1261,7 @@ int isLittleFourWinds(const GameState& state, int player,
   bool pair = false;
   int pons = 0;
   for (const auto& node : branch) {
-    switch (node->start.toUint8_t()) {
+    switch (node->start().toUint8_t()) {
       case Piece::Type::kEastWind:
       case Piece::Type::kSouthWind:
       case Piece::Type::kWestWind:
@@ -1270,7 +1270,7 @@ int isLittleFourWinds(const GameState& state, int player,
       default:
         continue;
     }
-    if (node->type != Node::kPair) {
+    if (node->type() != Node::kPair) {
       pons++;
     } else {
       if (pair) {
@@ -1304,7 +1304,7 @@ int isBigFourWinds(const GameState& state, int player,
                    const std::vector<const mahjong::Node*>& branch) {
   int pons = 0;
   for (const auto& node : branch) {
-    switch (node->start.toUint8_t()) {
+    switch (node->start().toUint8_t()) {
       case Piece::Type::kEastWind:
       case Piece::Type::kSouthWind:
       case Piece::Type::kWestWind:
@@ -1313,7 +1313,7 @@ int isBigFourWinds(const GameState& state, int player,
       default:
         continue;
     }
-    if (node->type == Node::kPair) {
+    if (node->type() == Node::kPair) {
       return 0;
     }
     pons++;

--- a/src/analysis/handtree.cc
+++ b/src/analysis/handtree.cc
@@ -1,16 +1,14 @@
 #include <algorithm>
-#include <array>
-#include <cstddef>
-#include <cstdint>
-#include <fstream>  // IWYU pragma: keep
+#include <fstream>
 #include <iostream>
-#include <iterator>
+#include <map>
 #include <memory>
 #include <utility>
 #include <vector>
 
 #include "analysis.h"
 #include "types/handnode.h"
+#include "types/pieces.h"
 #include "types/piecetype.h"
 
 namespace mahjong {
@@ -19,138 +17,107 @@ struct Breakdown {
   std::unique_ptr<Node> rootNode;
   Node* currentNode{};
   bool paired = false;
-  int minPossible{};
   int id = 0;
-  std::array<int8_t, Piece::kPiecesize> counts = {};
-  std::vector<int> possibilities;
+  std::map<Piece, int> counts;
+  std::map<Piece, int> possibilities;
   std::vector<Piece> pieces;
 };
 
 namespace {
 
 const int kMaxPossible = 14;
-
-bool possibleChiForward(const std::array<int8_t, Piece::kPiecesize> counts,
-                        Piece p) {
-  if (p.isHonor()) {
+bool possibleChiForward(const std::map<Piece, int>& counts, Piece p) {
+  if (p.isHonor() || !counts.contains(p) || !counts.contains(p + 1) ||
+      !counts.contains(p + 2)) {
     return false;
   }
-  return counts.at((p).toUint8_t()) > 0 && counts.at((p + 1).toUint8_t()) > 0 &&
-         counts.at((p + 2).toUint8_t()) > 0;
+  return counts.at(p) > 0 && counts.at(p + 1) > 0 && counts.at(p + 2) > 0;
 }
 
-int possibleChis(const std::array<int8_t, Piece::kPiecesize> counts, Piece p) {
-  return p.isHonor() ? 0
-                     : ((static_cast<int>(possibleChiForward(counts, p)) +
-                         static_cast<int>(possibleChiForward(counts, p - 1)) +
-                         static_cast<int>(possibleChiForward(counts, p - 2))));
+int possibleChis(const std::map<Piece, int>& counts, Piece p) {
+  int chi_count = possibleChiForward(counts, p) ? 1 : 0;
+  chi_count += possibleChiForward(counts, p - 1) ? 1 : 0;
+  chi_count += possibleChiForward(counts, p - 2) ? 1 : 0;
+  return chi_count;
 }
 
-bool anyPossibleChi(const std::array<int8_t, Piece::kPiecesize> counts,
-                    Piece p) {
+bool anyPossibleChi(const std::map<Piece, int>& counts, Piece p) {
   return possibleChis(counts, p) > 0;
 }
 
-bool possiblePair(const std::array<int8_t, Piece::kPiecesize> counts, Piece p) {
-  return (counts.at(p.toUint8_t()) == 2);
+bool possiblePair(const std::map<Piece, int>& counts, Piece p) {
+  return counts.contains(p) && counts.at(p) == 2;
 }
 
-bool possiblePon(const std::array<int8_t, Piece::kPiecesize> counts, Piece p) {
-  return counts.at(p.toUint8_t()) == 3;
+bool possiblePon(const std::map<Piece, int>& counts, Piece p) {
+  return counts.contains(p) && counts.at(p) == 3;
 }
 
 void countPieces(Breakdown* b) {
   for (const auto& p : b->pieces) {
-    b->counts.at(p.toUint8_t())++;
+    b->counts[p]++;
   }
 }
 
-void updatePossibilities(Breakdown* b) {
-  b->possibilities.resize(b->pieces.size());
-  b->minPossible = kMaxPossible;
-  for (size_t i = 0; i < b->pieces.size(); i++) {
-    b->possibilities.at(i) = 0;
-    b->possibilities.at(i) += possibleChis(b->counts, b->pieces.at(i));
-    b->possibilities.at(i) +=
-        b->paired ? 0
-                  : static_cast<int>(possiblePair(b->counts, b->pieces.at(i)));
-    b->possibilities.at(i) +=
-        static_cast<int>(possiblePon(b->counts, b->pieces.at(i)));
-    b->minPossible = b->possibilities.at(i) < b->minPossible
-                         ? b->possibilities.at(i)
-                         : b->minPossible;
+Piece updatePossibilities(Breakdown* b) {
+  b->possibilities.clear();
+  int min_possible = kMaxPossible;
+  Piece min_possible_piece = kError;
+  for (const auto& piece : b->pieces) {
+    b->possibilities[piece] += possibleChis(b->counts, piece);
+    if (!b->paired && possiblePair(b->counts, piece)) {
+      b->possibilities[piece]++;
+    }
+    if (possiblePon(b->counts, piece)) {
+      b->possibilities[piece]++;
+    }
+    if (b->possibilities[piece] < min_possible) {
+      min_possible = b->possibilities[piece];
+      min_possible_piece = piece;
+    }
   }
+  return min_possible_piece;
 }
 
-Node* addLeaf(Breakdown* b, Piece start, Node::Type type) {
-  b->currentNode->leaves.push_back(std::make_unique<Node>(
-      b->id++,                       // id
-      type,                          // type
-      start,                         // Start
-      b->currentNode,                // parent
-      b->currentNode->leaves.size()  // leafPosInParent
-      ));
-  return b->currentNode->leaves.back().get();
-}
-
-void breakdownForwardChi(Breakdown* b, int piecePos) {
-  const Piece start = b->pieces[piecePos];
+void breakdownForwardChi(Breakdown* b, Piece piece) {
   for (int i = 0; i < 3; i++) {
-    b->counts.at((start + i).toUint8_t())--;
-    if (b->counts.at((start + i).toUint8_t()) == 0) {
+    b->counts[piece + i]--;
+    if (b->counts[piece + i] == 0) {
       b->pieces.erase(
-          std::remove(b->pieces.begin(), b->pieces.end(), (start + i)),
+          std::remove(b->pieces.begin(), b->pieces.end(), piece + i),
           b->pieces.end());
     }
   }
-  b->currentNode = addLeaf(b, start, Node::kChiSet);
+  b->currentNode = b->currentNode->addLeaf(piece, Node::kChiSet, b->id++);
 }
 
-void breakdownPon(Breakdown* b, int piecePos) {
-  const Piece start = b->pieces[piecePos];
-  b->counts.at(b->pieces[piecePos].toUint8_t()) -= 3;
-  if (b->counts.at(b->pieces[piecePos].toUint8_t()) == 0) {
-    b->pieces.erase(
-        std::remove(b->pieces.begin(), b->pieces.end(), b->pieces[piecePos]),
-        b->pieces.end());
+void breakdownPon(Breakdown* b, Piece piece) {
+  b->counts[piece] -= 3;
+  if (b->counts[piece] == 0) {
+    b->pieces.erase(std::remove(b->pieces.begin(), b->pieces.end(), piece),
+                    b->pieces.end());
   }
-  b->currentNode = addLeaf(b, start, Node::kPonSet);
+  b->currentNode = b->currentNode->addLeaf(piece, Node::kPonSet, b->id++);
 }
 
-void breakdownPair(Breakdown* b, int piecePos) {
+void breakdownPair(Breakdown* b, Piece piece) {
   b->paired = true;
-  const Piece start = b->pieces[piecePos];
-  b->counts.at(b->pieces[piecePos].toUint8_t()) -= 2;
-  if (b->counts.at(b->pieces[piecePos].toUint8_t()) == 0) {
-    b->pieces.erase(
-        std::remove(b->pieces.begin(), b->pieces.end(), b->pieces[piecePos]),
-        b->pieces.end());
+  b->counts[piece] -= 2;
+  if (b->counts[piece] == 0) {
+    b->pieces.erase(std::remove(b->pieces.begin(), b->pieces.end(), piece),
+                    b->pieces.end());
   }
-  b->currentNode = addLeaf(b, start, Node::kPair);
+  b->currentNode = b->currentNode->addLeaf(piece, Node::kPair, b->id++);
 }
 
-void breakdownSingle(Breakdown* b, int piecePos) {
-  b->currentNode = addLeaf(b, b->pieces[piecePos], Node::kSingle);
+void breakdownSingle(Breakdown* b, Piece piece) {
+  b->currentNode = b->currentNode->addLeaf(piece, Node::kSingle, b->id++);
 
-  b->counts.at(b->pieces[piecePos].toUint8_t())--;
-  if (b->counts.at(b->pieces[piecePos].toUint8_t()) == 0) {
-    b->pieces.erase(
-        std::remove(b->pieces.begin(), b->pieces.end(), b->pieces[piecePos]),
-        b->pieces.end());
+  b->counts[piece]--;
+  if (b->counts[piece] == 0) {
+    b->pieces.erase(std::remove(b->pieces.begin(), b->pieces.end(), piece),
+                    b->pieces.end());
   }
-}
-
-int getNextPiece(Breakdown* b) {
-  int piece_pos = 0;
-  for (size_t i = 0; i < b->pieces.size(); i++) {
-    if (b->possibilities.at(i) <= b->possibilities[piece_pos]) {
-      piece_pos = i;
-      if (b->possibilities.at(i) == b->minPossible) {
-        break;
-      }
-    }
-  }
-  return piece_pos;
 }
 
 void resetCounts(Breakdown* b, const Node* target) {
@@ -162,45 +129,45 @@ void resetCounts(Breakdown* b, const Node* target) {
     throw -1;
   }
   while (b->currentNode != target) {
-    if (b->currentNode->parent == nullptr) {
+    if (b->currentNode->parent() == nullptr) {
       std::cerr << "reset Failure: parent node nullptr." << '\n';
       std::ofstream os("error.gv");
       b->rootNode->DumpAsDot(os);
       os.close();
       throw -2;
     }
-    if (b->currentNode->parent->type == Node::kError) {
+    if (b->currentNode->parent()->type() == Node::kError) {
       std::cerr << "reset Failure: reset up to an error." << '\n';
       std::ofstream os("error.gv");
       b->rootNode->DumpAsDot(os);
       os.close();
       throw -4;
     }
-    if (b->currentNode->type == Node::kChiSet) {
+    if (b->currentNode->type() == Node::kChiSet) {
       for (int i = 0; i < 3; i++) {
-        if (b->counts.at((b->currentNode->start + i).toUint8_t()) == 0) {
-          b->pieces.push_back(Piece{b->currentNode->start + i});
+        if (b->counts[b->currentNode->start() + i] == 0) {
+          b->pieces.push_back(Piece{b->currentNode->start() + i});
           std::sort(b->pieces.begin(), b->pieces.end());
         }
-        b->counts.at((b->currentNode->start + i).toUint8_t())++;
+        b->counts[b->currentNode->start() + i]++;
       }
     } else {
-      if (b->counts.at(b->currentNode->start.toUint8_t()) == 0) {
-        b->pieces.emplace_back(b->currentNode->start);
+      if (b->counts[b->currentNode->start()] == 0) {
+        b->pieces.emplace_back(b->currentNode->start());
         std::sort(b->pieces.begin(), b->pieces.end());
       }
-      if (b->currentNode->type == Node::kSingle) {
-        b->counts.at(b->currentNode->start.toUint8_t())++;
+      if (b->currentNode->type() == Node::kSingle) {
+        b->counts[b->currentNode->start()]++;
       }
-      if (b->currentNode->type == Node::kPair) {
+      if (b->currentNode->type() == Node::kPair) {
         b->paired = false;
-        b->counts.at(b->currentNode->start.toUint8_t()) += 2;
+        b->counts[b->currentNode->start()] += 2;
       }
-      if (b->currentNode->type == Node::kPonSet) {
-        b->counts.at(b->currentNode->start.toUint8_t()) += 3;
+      if (b->currentNode->type() == Node::kPonSet) {
+        b->counts[b->currentNode->start()] += 3;
       }
     }
-    b->currentNode = b->currentNode->parent;
+    b->currentNode = b->currentNode->parent();
   }
 }
 
@@ -211,81 +178,78 @@ void driver(Breakdown* b) {
   // - If a tile has multiple ways, try each possibility
   // - Continue until all tiles are in groups
 
-  // While there are ungrouped pieces
-  for (updatePossibilities(b); !b->pieces.empty(); updatePossibilities(b)) {
-    // Get the piece with minimum possibilities
-    const int piece_pos = getNextPiece(b);
-
-    if (b->possibilities[piece_pos] == 0) {
+  // While there are ungrouped pieces, get the piece with minimum possibilities
+  for (Piece current_piece = updatePossibilities(b); !b->pieces.empty();
+       current_piece = updatePossibilities(b)) {
+    if (b->possibilities[current_piece] == 0) {
       // No valid grouping possible, single piece
-      breakdownSingle(b, piece_pos);
+      breakdownSingle(b, current_piece);
       continue;
     }
 
-    if (b->possibilities[piece_pos] == 1) {
+    if (b->possibilities[current_piece] == 1) {
       // One way to be grouped, use it
-      if (anyPossibleChi(b->counts, b->pieces[piece_pos])) {
+      if (anyPossibleChi(b->counts, current_piece)) {
         // A chi is possible, determine how it can be a part of one
         for (int i = 0; i < 3; i++) {
-          const Piece chi_start = b->pieces[piece_pos] - i;
+          const Piece chi_start = current_piece - i;
           // Check if we can start a chi with this piece
           if (possibleChiForward(b->counts, chi_start)) {
             // Find the position of chi_start in the pieces vector
-            auto it = std::find(b->pieces.begin(), b->pieces.end(), chi_start);
-            if (it != b->pieces.end()) {
-              const int chi_start_pos = std::distance(b->pieces.begin(), it);
-              breakdownForwardChi(b, chi_start_pos);
+            auto piece_itr =
+                std::find(b->pieces.begin(), b->pieces.end(), chi_start);
+            if (piece_itr != b->pieces.end()) {
+              breakdownForwardChi(b, *piece_itr);
             }
             break;
           }
         }
         continue;
       }
-      if (possiblePon(b->counts, b->pieces[piece_pos])) {
+      if (possiblePon(b->counts, current_piece)) {
         // A pon is possible
-        breakdownPon(b, piece_pos);
+        breakdownPon(b, current_piece);
         continue;
       }
-      if (possiblePair(b->counts, b->pieces[piece_pos])) {
+      if (possiblePair(b->counts, current_piece)) {
         // A pair is possible
-        breakdownPair(b, piece_pos);
+        breakdownPair(b, current_piece);
         continue;
       }
     }
-    if (b->possibilities[piece_pos] >= 2) {
+    if (b->possibilities[current_piece] >= 2) {
       // Tile has multiple groups, we need to check branches
 
       // Save current position in tree so we can backtrack
       auto* current = b->currentNode;
 
       // Check grouping possibilities
-      const bool can_chi_start =
-          possibleChiForward(b->counts, b->pieces[piece_pos] - 0);
+      const bool can_chi_start = possibleChiForward(b->counts, current_piece);
 
       bool can_chi_middle = false;
-      int chi_middle_pos = -1;
-      if (possibleChiForward(b->counts, b->pieces[piece_pos] - 1)) {
-        const Piece chi_start = b->pieces[piece_pos] - 1;
+      Piece chi_middle_piece;
+      if (possibleChiForward(b->counts, current_piece - 1)) {
+        const Piece chi_start = current_piece - 1;
         auto it = std::find(b->pieces.begin(), b->pieces.end(), chi_start);
         if (it != b->pieces.end()) {
           can_chi_middle = true;
-          chi_middle_pos = std::distance(b->pieces.begin(), it);
+          chi_middle_piece = *it;
         }
       }
 
       bool can_chi_end = false;
-      int chi_end_pos = -1;
-      if (possibleChiForward(b->counts, b->pieces[piece_pos] - 2)) {
-        const Piece chi_start = b->pieces[piece_pos] - 2;
+      Piece chi_end_piece;
+      if (possibleChiForward(b->counts, current_piece - 2)) {
+        const Piece chi_start = current_piece - 2;
         auto it = std::find(b->pieces.begin(), b->pieces.end(), chi_start);
         if (it != b->pieces.end()) {
           can_chi_end = true;
-          chi_end_pos = std::distance(b->pieces.begin(), it);
+          chi_end_piece = *it;
         }
       }
 
-      const bool can_pon = possiblePon(b->counts, b->pieces[piece_pos]);
-      const bool can_pair = possiblePair(b->counts, b->pieces[piece_pos]);
+      const bool can_pon = possiblePon(b->counts, current_piece);
+      const bool can_pair = possiblePair(b->counts, current_piece);
 
       // Count total branches that will actually execute
       int total_branches = 0;
@@ -311,7 +275,7 @@ void driver(Breakdown* b) {
       if (can_chi_start) {
         // Can be the beginning of a chi
         current_branch++;
-        breakdownForwardChi(b, piece_pos);
+        breakdownForwardChi(b, current_piece);
         driver(b);
         if (current_branch < total_branches) {
           resetCounts(b, current);
@@ -321,7 +285,7 @@ void driver(Breakdown* b) {
       if (can_chi_middle) {
         // Can be the middle of a chi
         current_branch++;
-        breakdownForwardChi(b, chi_middle_pos);
+        breakdownForwardChi(b, chi_middle_piece);
         driver(b);
         if (current_branch < total_branches) {
           resetCounts(b, current);
@@ -331,7 +295,7 @@ void driver(Breakdown* b) {
       if (can_chi_end) {
         // Can be the end of a chi
         current_branch++;
-        breakdownForwardChi(b, chi_end_pos);
+        breakdownForwardChi(b, chi_end_piece);
         driver(b);
         if (current_branch < total_branches) {
           resetCounts(b, current);
@@ -341,7 +305,7 @@ void driver(Breakdown* b) {
       if (can_pon) {
         // Can be a pon
         current_branch++;
-        breakdownPon(b, piece_pos);
+        breakdownPon(b, current_piece);
         driver(b);
         if (current_branch < total_branches) {
           resetCounts(b, current);
@@ -351,7 +315,7 @@ void driver(Breakdown* b) {
       if (can_pair) {
         // Can be a pair
         current_branch++;
-        breakdownPair(b, piece_pos);
+        breakdownPair(b, current_piece);
         driver(b);
         if (current_branch < total_branches) {
           resetCounts(b, current);

--- a/src/analysis/possiblesets.cc
+++ b/src/analysis/possiblesets.cc
@@ -196,7 +196,7 @@ bool TestStdForm(const std::vector<Piece>& hand) {
     bool complete = true;
     const std::vector<const Node*> singles;
     for (const auto& node : branch) {
-      if (node->type == Node::kSingle) {
+      if (node->type() == Node::kSingle) {
         complete = false;
         break;
       }

--- a/src/controllers/gentlemanbot.cc
+++ b/src/controllers/gentlemanbot.cc
@@ -70,18 +70,12 @@ Piece GentlemanBot::getDiscard() {
   std::vector<Piece> third_tier_discards;
 
   std::array<int8_t, Piece::kPiecesize> counts = {};
-  auto symbolic_hand = breakdownHand(hand_);
-  auto* current_node = symbolic_hand.get();
+  const std::unique_ptr<Node> symbolic_hand = breakdownHand(hand_);
 
-  while (true) {
-    if (current_node->type == Node::kSingle) {
-      free_pieces.push_back(current_node->start);
+  for (const auto& leaf : *symbolic_hand) {
+    if (leaf.type() == Node::kSingle) {
+      free_pieces.push_back(leaf.start());
     }
-    if (current_node->leaves.empty()) {
-      break;
-    }
-
-    current_node = current_node->leaves[0].get();
   }
 
   CountPieces(counts, free_pieces);

--- a/src/controllers/thricebot.cc
+++ b/src/controllers/thricebot.cc
@@ -151,7 +151,7 @@ Piece ThriceBot::popDiscard() {
       index_of_lowest = i;
     }
   }
-  Piece p = hand_[index_of_lowest].piece;
+  const Piece p = hand_[index_of_lowest].piece;
   hand_.erase(hand_.begin() + index_of_lowest);
   discarded_.at(p.toUint8_t())++;
   return p;

--- a/src/types/handnode.cc
+++ b/src/types/handnode.cc
@@ -49,6 +49,23 @@ std::string NodeTypeToShapeStr(uint8_t nodetype) {
 }
 }  // namespace
 
+std::string Node::typeToStr() const {
+  switch (type_) {
+    case kChiSet:
+      return "Chi";
+    case kPonSet:
+      return "Pon";
+    case kPair:
+      return "Pair";
+    case kSingle:
+      return "Single";
+    case kRoot:
+      return "RootNode";
+    default:
+      return "Invalid Type";
+  }
+}
+
 Node::ConstIterator Node::begin() const {
   return ConstIterator(this, /*end=*/false);
 }
@@ -66,44 +83,40 @@ Node::Iterator Node::end() {
 }
 
 bool Node::operator!=(const Node& n) const {
-  return id == n.id && type == n.type && start == n.start &&
-         parent == n.parent && leaves == n.leaves &&
-         leafPosInParent == n.leafPosInParent;
+  return id_ == n.id_ && type_ == n.type_ && start_ == n.start_ &&
+         parent_ == n.parent_ && leaves_ == n.leaves_;
 }
 
-// dont free parent, its not owned
-Node::~Node() = default;
-
 Node::ConstIterator& Node::ConstIterator::operator++() {
-  if (!root_->leaves.empty()) {
-    root_ = root_->leaves.front().get();
+  if (!root_->leaves_.empty()) {
+    root_ = root_->leaves_.front().get();
     return *this;
   }
-  if (root_->parent == nullptr) {
+  if (root_->parent_ == nullptr) {
     end_ = true;
     return *this;
   }
   const Node* traveler = root_;
-  size_t leaf_pos_next = traveler->leafPosInParent + 1;
-  while ((traveler->parent != nullptr) &&
-         traveler->parent->leaves.size() <= leaf_pos_next) {
-    traveler = traveler->parent;
-    leaf_pos_next = traveler->leafPosInParent + 1;
+  size_t leaf_pos_next = traveler->leafPosInParent() + 1;
+  while ((traveler->parent_ != nullptr) &&
+         traveler->parent_->leaves_.size() <= leaf_pos_next) {
+    traveler = traveler->parent_;
+    leaf_pos_next = traveler->leafPosInParent() + 1;
   }
-  if (traveler->parent == nullptr) {
+  if (traveler->parent_ == nullptr) {
     end_ = true;
     return *this;
   }
 
-  if (traveler->parent->leaves.size() > leaf_pos_next &&
-      traveler->parent->leaves[leaf_pos_next].get() != root_) {
-    root_ = traveler->parent->leaves[leaf_pos_next].get();
+  if (traveler->parent()->leaves_.size() > leaf_pos_next &&
+      traveler->parent()->leaves_[leaf_pos_next].get() != root_) {
+    root_ = traveler->parent_->leaves_[leaf_pos_next].get();
     return *this;
   }
   std::cerr << "FORWARD TRAVERSAL FAILED: Set to end." << '\n';
   std::cerr << "ROOT: " << root_ << '\n';
-  if (traveler->parent != nullptr) {
-    std::cerr << "PARENT: " << traveler->parent << '\n';
+  if (traveler->parent_ != nullptr) {
+    std::cerr << "PARENT: " << traveler->parent_ << '\n';
   }
   std::cerr << "TRAVELER: " << *traveler << '\n';
   end_ = true;
@@ -135,12 +148,12 @@ std::ostream& Node::DumpAsTGF(std::ostream& os) const {
   std::vector<std::string> nodes;
   std::vector<std::string> connections;
   for (const auto& node : *this) {
-    nodes.push_back(std::to_string(node.id) + " Piece: " +
-                    (node.type != kRoot ? node.start.toStr() : "Root") +
+    nodes.push_back(std::to_string(node.id()) + " Piece: " +
+                    (node.type() != kRoot ? node.start().toStr() : "Root") +
                     " Type: " + node.typeToStr());
-    for (const auto& leaf : node.leaves) {
-      connections.push_back(std::to_string(node.id) + " " +
-                            std::to_string(leaf->id));
+    for (const auto& leaf : node.leaves_) {
+      connections.push_back(std::to_string(node.id()) + " " +
+                            std::to_string(leaf->id()));
     }
   }
   for (const auto& node : nodes) {
@@ -157,13 +170,14 @@ std::ostream& Node::DumpAsDot(std::ostream& os) const {
   std::vector<std::string> nodes;
   std::vector<std::string> connections;
   for (const auto& node : *this) {
-    nodes.push_back(std::to_string(node.id) + " [label=\"" + node.typeToStr() +
-                    ": " + (node.type != kRoot ? node.start.toStr() : "Root") +
-                    "\"" + ",shape=" + NodeTypeToShapeStr(node.type) +
-                    ",color=" + NodeTypeToColorStr(node.type) + "];");
-    for (const auto& leaf : node.leaves) {
-      connections.push_back(std::to_string(node.id) + " -> " +
-                            std::to_string(leaf->id) + ";");
+    nodes.push_back(std::to_string(node.id()) + " [label=\"" +
+                    node.typeToStr() + ": " +
+                    (node.type() != kRoot ? node.start().toStr() : "Root") +
+                    "\"" + ",shape=" + NodeTypeToShapeStr(node.type()) +
+                    ",color=" + NodeTypeToColorStr(node.type()) + "];");
+    for (const auto& leaf : node.leaves_) {
+      connections.push_back(std::to_string(node.id()) + " -> " +
+                            std::to_string(leaf->id()) + ";");
     }
   }
   os << "digraph {" << '\n';
@@ -201,28 +215,28 @@ std::vector<std::vector<const Node*>> Node::AsBranchVectors(const Node* root) {
       continue;
     }
 
-    if (!current->leaves.empty()) {
-      nodeloc.push_back(current->leaves[0].get());
+    if (!current->leaves().empty()) {
+      nodeloc.push_back(current->leaves()[0].get());
     } else {
       branches.push_back(nodeloc);
-      size_t next = current->leafPosInParent + 1;
+      size_t next = current->leafPosInParent() + 1;
 
-      while ((current->parent != nullptr) &&
-             current->parent->leaves.size() <= next) {
+      while ((current->parent() != nullptr) &&
+             current->parent()->leaves().size() <= next) {
         nodeloc.pop_back();
         if (nodeloc.empty()) {
           break;
         }
         current = nodeloc.back();
-        next = current->leafPosInParent + 1;
+        next = current->leafPosInParent() + 1;
       }
 
-      if (nodeloc.empty() || current->parent == nullptr) {
+      if (nodeloc.empty() || current->parent() == nullptr) {
         nodeloc.pop_back();
       } else {
         nodeloc.pop_back();
-        if (!nodeloc.empty() && next < nodeloc.back()->leaves.size()) {
-          nodeloc.push_back(nodeloc.back()->leaves[next].get());
+        if (!nodeloc.empty() && next < nodeloc.back()->leaves().size()) {
+          nodeloc.push_back(nodeloc.back()->leaves()[next].get());
         } else {
           std::cerr << "ERROR: AsBranchVectors next index " << next
                     << " out of bounds\n";
@@ -237,8 +251,9 @@ std::vector<std::vector<const Node*>> Node::AsBranchVectors(const Node* root) {
 bool Node::IsComplete() const {
   auto branches = AsBranchVectors(this);
   return std::ranges::any_of(branches, [](auto branch) {
-    return std::none_of(branch.begin(), branch.end(),
-                        [](auto node) { return node->type == Node::kSingle; });
+    return std::none_of(branch.begin(), branch.end(), [](auto node) {
+      return node->type() == Node::kSingle;
+    });
   });
 }
 }  // namespace mahjong

--- a/src/types/handnode.cc
+++ b/src/types/handnode.cc
@@ -108,8 +108,8 @@ Node::ConstIterator& Node::ConstIterator::operator++() {
     return *this;
   }
 
-  if (traveler->parent()->leaves_.size() > leaf_pos_next &&
-      traveler->parent()->leaves_[leaf_pos_next].get() != root_) {
+  if (traveler->parent_->leaves_.size() > leaf_pos_next &&
+      traveler->parent_->leaves_[leaf_pos_next].get() != root_) {
     root_ = traveler->parent_->leaves_[leaf_pos_next].get();
     return *this;
   }
@@ -215,14 +215,14 @@ std::vector<std::vector<const Node*>> Node::AsBranchVectors(const Node* root) {
       continue;
     }
 
-    if (!current->leaves().empty()) {
-      nodeloc.push_back(current->leaves()[0].get());
+    if (!current->leaves_.empty()) {
+      nodeloc.push_back(current->leaves_[0].get());
     } else {
       branches.push_back(nodeloc);
       size_t next = current->leafPosInParent() + 1;
 
-      while ((current->parent() != nullptr) &&
-             current->parent()->leaves().size() <= next) {
+      while ((current->parent_ != nullptr) &&
+             current->parent_->leaves_.size() <= next) {
         nodeloc.pop_back();
         if (nodeloc.empty()) {
           break;
@@ -231,12 +231,12 @@ std::vector<std::vector<const Node*>> Node::AsBranchVectors(const Node* root) {
         next = current->leafPosInParent() + 1;
       }
 
-      if (nodeloc.empty() || current->parent() == nullptr) {
+      if (nodeloc.empty() || current->parent_ == nullptr) {
         nodeloc.pop_back();
       } else {
         nodeloc.pop_back();
-        if (!nodeloc.empty() && next < nodeloc.back()->leaves().size()) {
-          nodeloc.push_back(nodeloc.back()->leaves()[next].get());
+        if (!nodeloc.empty() && next < nodeloc.back()->leaves_.size()) {
+          nodeloc.push_back(nodeloc.back()->leaves_[next].get());
         } else {
           std::cerr << "ERROR: AsBranchVectors next index " << next
                     << " out of bounds\n";

--- a/src/types/handnode.cc
+++ b/src/types/handnode.cc
@@ -148,12 +148,12 @@ std::ostream& Node::DumpAsTGF(std::ostream& os) const {
   std::vector<std::string> nodes;
   std::vector<std::string> connections;
   for (const auto& node : *this) {
-    nodes.push_back(std::to_string(node.id()) + " Piece: " +
-                    (node.type() != kRoot ? node.start().toStr() : "Root") +
+    nodes.push_back(std::to_string(node.id_) + " Piece: " +
+                    (node.type() != kRoot ? node.start_.toStr() : "Root") +
                     " Type: " + node.typeToStr());
     for (const auto& leaf : node.leaves_) {
-      connections.push_back(std::to_string(node.id()) + " " +
-                            std::to_string(leaf->id()));
+      connections.push_back(std::to_string(node.id_) + " " +
+                            std::to_string(leaf->id_));
     }
   }
   for (const auto& node : nodes) {
@@ -170,14 +170,14 @@ std::ostream& Node::DumpAsDot(std::ostream& os) const {
   std::vector<std::string> nodes;
   std::vector<std::string> connections;
   for (const auto& node : *this) {
-    nodes.push_back(std::to_string(node.id()) + " [label=\"" +
+    nodes.push_back(std::to_string(node.id_) + " [label=\"" +
                     node.typeToStr() + ": " +
-                    (node.type() != kRoot ? node.start().toStr() : "Root") +
-                    "\"" + ",shape=" + NodeTypeToShapeStr(node.type()) +
-                    ",color=" + NodeTypeToColorStr(node.type()) + "];");
+                    (node.type_ != kRoot ? node.start_.toStr() : "Root") +
+                    "\"" + ",shape=" + NodeTypeToShapeStr(node.type_) +
+                    ",color=" + NodeTypeToColorStr(node.type_) + "];");
     for (const auto& leaf : node.leaves_) {
-      connections.push_back(std::to_string(node.id()) + " -> " +
-                            std::to_string(leaf->id()) + ";");
+      connections.push_back(std::to_string(node.id_) + " -> " +
+                            std::to_string(leaf->id_) + ";");
     }
   }
   os << "digraph {" << '\n';
@@ -252,7 +252,7 @@ bool Node::IsComplete() const {
   auto branches = AsBranchVectors(this);
   return std::ranges::any_of(branches, [](auto branch) {
     return std::none_of(branch.begin(), branch.end(), [](auto node) {
-      return node->type() == Node::kSingle;
+      return node->type_ == Node::kSingle;
     });
   });
 }

--- a/src/types/handnode.h
+++ b/src/types/handnode.h
@@ -74,6 +74,9 @@ class Node : public std::enable_shared_from_this<Node> {
   [[nodiscard]] Iterator end();
 
   size_t leafPosInParent() const {
+    if(!parent_){
+      return 0;
+    }
     auto leaf_it = std::find_if(
         parent_->leaves_.begin(), parent_->leaves_.end(),
         [id = this->id_](const auto& leaf) { return leaf->id_ == id; });

--- a/src/types/handnode.h
+++ b/src/types/handnode.h
@@ -14,24 +14,30 @@ class Node : public std::enable_shared_from_this<Node> {
  public:
   enum Type { kError, kChiSet, kPonSet, kPair, kSingle, kRoot };
 
-  int id;
-  Type type;
-  Piece start;
-  Node* parent = nullptr;  // not owned.
-  std::vector<std::unique_ptr<Node>> leaves;
-  size_t leafPosInParent;
-
   bool operator!=(const Node& n) const;
 
-  Node(int id, Type type, Piece start, Node* parent = nullptr,
-       size_t leafPosInParent = 0)
-      : id(id),
-        type(type),
-        start(start),
-        parent(parent),
-        leafPosInParent(leafPosInParent) {}
+  Node(int id, Type type, Piece start, Node* parent = nullptr)
+      : id_(id), type_(type), start_(start), parent_(parent) {}
 
-  ~Node();
+  std::string typeToStr() const;
+
+  Node* addLeaf(Piece start, Node::Type type, int id) {
+    leaves_.push_back(std::make_unique<Node>(
+        /*id=*/id,
+        /*type=*/type,
+        /*start=*/start,
+        /*parent=*/this));
+    return leaves_.back().get();
+  }
+
+  [[nodiscard]] static std::vector<std::vector<const Node*>> AsBranchVectors(
+      const Node* root);
+
+  std::ostream& DumpAsTGF(std::ostream& os) const;
+  std::ostream& DumpAsDot(std::ostream& os) const;
+  [[nodiscard]] bool IsComplete() const;
+
+  // Iterators
   class ConstIterator {
     const Node* root_;
     bool end_;
@@ -62,33 +68,32 @@ class Node : public std::enable_shared_from_this<Node> {
     using pointer = Node*;
     using iterator_category = std::forward_iterator_tag;
   };
-
-  std::string typeToStr() const {
-    switch (type) {
-      case kChiSet:
-        return "Chi";
-      case kPonSet:
-        return "Pon";
-      case kPair:
-        return "Pair";
-      case kSingle:
-        return "Single";
-      case kRoot:
-        return "RootNode";
-      default:
-        return "Invalid Type";
-    }
-  }
-
-  std::ostream& DumpAsTGF(std::ostream& os) const;
-  std::ostream& DumpAsDot(std::ostream& os) const;
-  [[nodiscard]] static std::vector<std::vector<const Node*>> AsBranchVectors(
-      const Node* root);
-  [[nodiscard]] bool IsComplete() const;
   [[nodiscard]] ConstIterator begin() const;
   [[nodiscard]] ConstIterator end() const;
   [[nodiscard]] Iterator begin();
   [[nodiscard]] Iterator end();
+
+  size_t leafPosInParent() const {
+    auto leaf_it = std::find_if(
+        parent_->leaves_.begin(), parent_->leaves_.end(),
+        [id = this->id_](const auto& leaf) { return leaf->id_ == id; });
+    return std::distance(parent_->leaves_.begin(), leaf_it);
+  }
+
+  int id() const { return id_; }
+  Type type() const { return type_; }
+  Piece start() const { return start_; }
+  Node* parent() { return parent_; }
+  Node const* parent() const { return parent_; }
+  const std::vector<std::unique_ptr<Node>>& leaves() const { return leaves_; }
+  std::vector<std::unique_ptr<Node>>& leaves() { return leaves_; }
+
+ private:
+  int id_;
+  Type type_;
+  Piece start_;
+  Node* parent_ = nullptr;  // not owned.
+  std::vector<std::unique_ptr<Node>> leaves_;
 };
 
 }  // namespace mahjong

--- a/src/types/piecetype.h
+++ b/src/types/piecetype.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <functional>
 #include <string>
 
 #include "winds.h"
@@ -10,6 +11,7 @@ class Piece {
  public:
   Piece() = default;
   constexpr explicit Piece(uint8_t p) : p_(p) {}
+  constexpr Piece(const Piece& p) = default;
 
   // TERMINAL_BIT, SUIT_2, RED_FIVE, PIECE_4
   enum Type : std::uint8_t {
@@ -127,3 +129,11 @@ class Piece {
 };
 
 }  // namespace mahjong
+
+// Custom specialization of std::hash can be injected in namespace std.
+template <>
+struct std::hash<mahjong::Piece> {
+  std::size_t operator()(const mahjong::Piece& p) const noexcept {
+    return std::hash<uint8_t>{}(p.raw_value());
+  }
+};

--- a/src/types/typeprinter.cc
+++ b/src/types/typeprinter.cc
@@ -78,17 +78,17 @@ std::ostream& operator<<(std::ostream& os, const mahjong::Hand& hand) {
 }
 
 std::ostream& operator<<(std::ostream& os, const mahjong::Node& node) {
-  os << "{ id: " << node.id << ", type:" << node.typeToStr();
-  os << ", start:" << node.start.toStr();
+  os << "{ id: " << node.id() << ", type:" << node.typeToStr();
+  os << ", start:" << node.start().toStr();
   os << ", parent: "
-     << (node.parent != nullptr ? std::to_string(node.parent->id)
-                                : "No Parent");
+     << (node.parent() != nullptr ? std::to_string(node.parent()->id())
+                                  : "No Parent");
   os << ", leaves: [ ";
-  for (const auto& leaf : node.leaves) {
-    os << "id: " << leaf->id << ", ";
+  for (const auto& leaf : node.leaves()) {
+    os << "id: " << leaf->id() << ", ";
   }
   os << " ], "
-     << "leafPosInParent: " << node.leafPosInParent << " },";
+     << "leafPosInParent: " << node.leafPosInParent() << " },";
   os << '\n';
   return os;
 }

--- a/src/types/walls.cc
+++ b/src/types/walls.cc
@@ -63,7 +63,7 @@ Walls::Walls(std::vector<Piece> wall) {
 
 Piece Walls::TakePiece() {
   if (!livingWalls.empty()) {
-    Piece p = livingWalls.front();
+    const Piece p = livingWalls.front();
     livingWalls.erase(livingWalls.begin());
     return p;
   }
@@ -91,7 +91,7 @@ Piece Walls::TakeReplacementTile() {
     return kError;
   }
   replacements--;
-  Piece p = deadWall.front();
+  const Piece p = deadWall.front();
   deadWall.erase(deadWall.begin());
   deadWall.push_back(livingWalls.back());
   doraCount++;

--- a/tests/yakus/allpon.test.cc
+++ b/tests/yakus/allpon.test.cc
@@ -16,7 +16,7 @@
 
 namespace mahjong {
 
-TEST(isAllPons, DISABLED_2Han) {
+TEST(isAllPons, 2Han) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("111m222p888s666z44m"));
 
@@ -31,7 +31,7 @@ TEST(isAllPons, DISABLED_2Han) {
   FAIL();
 }
 
-TEST(isAllPons, DISABLED_WithKans) {
+TEST(isAllPons, WithKans) {
   const Meld meld = {
       .type = Meld::kKan,
       .start = Piece(kFivePin),
@@ -53,7 +53,7 @@ TEST(isAllPons, DISABLED_WithKans) {
   FAIL();
 }
 
-TEST(isAllPons, DISABLED_ConcealedKan) {
+TEST(isAllPons, ConcealedKan) {
   const Meld meld = {
       .type = Meld::kConcealedKan,
       .start = Piece(kFivePin),

--- a/tests/yakus/concealedpon.test.cc
+++ b/tests/yakus/concealedpon.test.cc
@@ -15,7 +15,7 @@
 #include "utils/handformer.h"
 
 namespace mahjong {
-TEST(isThreeConcealedPons, DISABLED_2Han) {
+TEST(isThreeConcealedPons, 2Han) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("111m111p111s666z44m"));
   game_state.hands[0].open = false;
@@ -31,7 +31,7 @@ TEST(isThreeConcealedPons, DISABLED_2Han) {
   FAIL();
 }
 
-TEST(isThreeConcealedPons, DISABLED_PonsMustBeConcealed) {
+TEST(isThreeConcealedPons, PonsMustBeConcealed) {
   auto meld = Meld();
   meld.type = Meld::kChi;
   meld.start = Piece(kTwoBamboo);
@@ -52,7 +52,7 @@ TEST(isThreeConcealedPons, DISABLED_PonsMustBeConcealed) {
   FAIL();
 }
 
-TEST(isThreeConcealedPons, DISABLED_CanHaveAdditionalOpenPon) {
+TEST(isThreeConcealedPons, CanHaveAdditionalOpenPon) {
   auto meld = Meld();
   meld.type = Meld::kPon;
   meld.start = Piece(kTwoBamboo);

--- a/tests/yakus/littlethreedragons.test.cc
+++ b/tests/yakus/littlethreedragons.test.cc
@@ -16,7 +16,7 @@
 
 namespace mahjong {
 
-TEST(isLittleThreeDragons, DISABLED_2Han) {
+TEST(isLittleThreeDragons, 2Han) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("555z666z111m222p77z"));
   game_state.hands[0].open = false;
@@ -32,7 +32,7 @@ TEST(isLittleThreeDragons, DISABLED_2Han) {
   FAIL();
 }
 
-TEST(isLittleThreeDragons, DISABLED_WhenOpen) {
+TEST(isLittleThreeDragons, WhenOpen) {
   const Meld meld = {
       .type = Meld::kPon,
       .start = Piece(kWhiteDragon),

--- a/tests/yakus/mixedtriplechi.test.cc
+++ b/tests/yakus/mixedtriplechi.test.cc
@@ -12,7 +12,7 @@
 
 namespace mahjong {
 
-TEST(isMixedTripleChi, DISABLED_Open) {
+TEST(isMixedTripleChi, Open) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123p123m123s555p11z"));
   game_state.hands[0].open = true;
@@ -28,7 +28,7 @@ TEST(isMixedTripleChi, DISABLED_Open) {
   FAIL();
 }
 
-TEST(isMixedTripleChi, DISABLED_Closed) {
+TEST(isMixedTripleChi, Closed) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123p123m123s555p11z"));
   game_state.hands[0].open = false;

--- a/tests/yakus/outsidehand.test.cc
+++ b/tests/yakus/outsidehand.test.cc
@@ -12,7 +12,7 @@
 
 namespace mahjong {
 
-TEST(isOutsideHand, DISABLED_Open) {
+TEST(isOutsideHand, Open) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m789m111z999s55z"));
   game_state.hands[0].open = true;
@@ -28,7 +28,7 @@ TEST(isOutsideHand, DISABLED_Open) {
   FAIL();
 }
 
-TEST(isOutsideHand, DISABLED_Closed) {
+TEST(isOutsideHand, Closed) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m789m111z999s55z"));
   game_state.hands[0].open = false;

--- a/tests/yakus/pinfu.test.cc
+++ b/tests/yakus/pinfu.test.cc
@@ -2,6 +2,7 @@
 #include <array>
 #include <memory>
 #include <string>
+#include <iostream>
 
 #include "analysis/analysis.h"
 #include "analysis/hands.h"
@@ -14,14 +15,14 @@
 
 namespace mahjong {
 
-TEST(isPinfu, DISABLED_1Han) {
+TEST(isPinfu, 1Han) {
   auto game_state = GameState();
-  game_state.hands[0] = Hand(HandFromNotation("123m456p234s678z44m"));
+  game_state.hands[0] = Hand(HandFromNotation("123m456p234678s44m"));
   game_state.hands[0].open = false;
   game_state.pendingPiece = Piece(kFourPin);
 
   auto root = breakdownHand(game_state.hands.at(0).live);
-
+  root->DumpAsDot(std::cerr);
   for (const auto& branch : Node::AsBranchVectors(root.get())) {
     if (mahjong::isPinfu(game_state, 0, branch) == 1) {
       SUCCEED();
@@ -31,14 +32,14 @@ TEST(isPinfu, DISABLED_1Han) {
   FAIL();
 }
 
-TEST(isPinfu, DISABLED_BadHand) {
+TEST(isPinfu, BadHand) {
   auto game_state = GameState();
-  game_state.hands[0] = Hand(HandFromNotation("123m555p234s678z44m"));
+  game_state.hands[0] = Hand(HandFromNotation("123m555p234678s44m"));
   game_state.hands[0].open = false;
   game_state.pendingPiece = Piece(kTwoBamboo);
 
   auto root = breakdownHand(game_state.hands.at(0).live);
-
+  root->DumpAsDot(std::cerr);
   for (const auto& branch : Node::AsBranchVectors(root.get())) {
     if (mahjong::isPinfu(game_state, 0, branch) == 1) {
       FAIL();
@@ -48,14 +49,14 @@ TEST(isPinfu, DISABLED_BadHand) {
   SUCCEED();
 }
 
-TEST(isPinfu, DISABLED_CantBeOpen) {
+TEST(isPinfu, CantBeOpen) {
   auto game_state = GameState();
-  game_state.hands[0] = Hand(HandFromNotation("123m456p234s678z44m"));
+  game_state.hands[0] = Hand(HandFromNotation("123m456p234678s44m"));
   game_state.hands[0].open = true;
   game_state.pendingPiece = Piece(kFourPin);
 
   auto root = breakdownHand(game_state.hands.at(0).live);
-
+  root->DumpAsDot(std::cerr);
   for (const auto& branch : Node::AsBranchVectors(root.get())) {
     if (mahjong::isPinfu(game_state, 0, branch) == 1) {
       FAIL();
@@ -67,12 +68,12 @@ TEST(isPinfu, DISABLED_CantBeOpen) {
 
 TEST(isPinfu, DISABLED_NeedTwoWait) {
   auto game_state = GameState();
-  game_state.hands[0] = Hand(HandFromNotation("123m456p234s678z44m"));
+  game_state.hands[0] = Hand(HandFromNotation("123m456p234678s44m"));
   game_state.hands[0].open = false;
   game_state.pendingPiece = Piece(kFivePin);
 
   auto root = breakdownHand(game_state.hands.at(0).live);
-
+  root->DumpAsDot(std::cerr);
   for (const auto& branch : Node::AsBranchVectors(root.get())) {
     if (mahjong::isPinfu(game_state, 0, branch) == 1) {
       FAIL();

--- a/tests/yakus/puredoublechi.test.cc
+++ b/tests/yakus/puredoublechi.test.cc
@@ -12,7 +12,7 @@
 
 namespace mahjong {
 
-TEST(isPureDoubleChi, DISABLED_1Han) {
+TEST(isPureDoubleChi, 1Han) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("234m234m555p888s88p"));
   game_state.hands[0].open = false;

--- a/tests/yakus/purestraight.test.cc
+++ b/tests/yakus/purestraight.test.cc
@@ -12,7 +12,7 @@
 
 namespace mahjong {
 
-TEST(isPureStraight, DISABLED_Open) {
+TEST(isPureStraight, Open) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m789m555p11z"));
   game_state.hands[0].open = true;
@@ -28,7 +28,7 @@ TEST(isPureStraight, DISABLED_Open) {
   FAIL();
 }
 
-TEST(isPureStraight, DISABLED_Closed) {
+TEST(isPureStraight, Closed) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("123m456m789m555p11z"));
   game_state.hands[0].open = false;

--- a/tests/yakus/triplepon.test.cc
+++ b/tests/yakus/triplepon.test.cc
@@ -12,7 +12,7 @@
 
 namespace mahjong {
 
-TEST(isTriplePon, DISABLED_2Han) {
+TEST(isTriplePon, 2Han) {
   auto game_state = GameState();
   game_state.hands[0] = Hand(HandFromNotation("111m111p111s666z44m"));
 


### PR DESCRIPTION
* Move HandNode functions out of HandTree analysis, and encapsulate public HandNode members. 
* Calculate leafPositionInParent in line rather than as part of the state, avoids destructor complexity.
* Made some minor fixes to tests that were crashing, and enabled newly passing tests.