### PR TITLE
Yaku registration

### DIFF
--- a/src/scoring/CMakeLists.txt
+++ b/src/scoring/CMakeLists.txt
@@ -2,7 +2,7 @@ add_subdirectory(yakus)
 
 target_sources(
   libmahjong
-  PRIVATE "scoring.cc"
+  PRIVATE "scoring.cc" "yakus.cc"
   PUBLIC FILE_SET
          HEADERS
          BASE_DIRS

--- a/src/scoring/scoring.cc
+++ b/src/scoring/scoring.cc
@@ -72,7 +72,7 @@ Score scoreHand(const GameState& state, int player) {
       continue;
     }
 
-    for (const auto& yaku : Yakus::GetYakus()) {
+    for (const auto& yaku : Yakus::Instance().GetYakus()) {
       if (yaku.type == Yaku::kClosed && state.hands[player].open) {
         continue;
       }
@@ -268,7 +268,7 @@ bool isComplete(const GameState& state, int player) {
         })) {
       continue;
     }
-    if (std::ranges::any_of(Yakus::GetYakus(),
+    if (std::ranges::any_of(Yakus::Instance().GetYakus(),
                             [&state, player, &branch](const auto& yaku) {
                               return yaku.is_yaku_func(state, player, branch);
                             })) {

--- a/src/scoring/scoring.cc
+++ b/src/scoring/scoring.cc
@@ -72,12 +72,27 @@ Score scoreHand(const GameState& state, int player) {
       continue;
     }
 
-    for (const auto& yaku_function : yaku::kYakuFunctions) {
-      branchscore.han += yaku_function(state, player, branch);
+    for (const auto& yaku : Yakus::GetYakus()) {
+      if (yaku.type == Yaku::kClosed && state.hands[player].open) {
+        continue;
+      }
+      if (!yaku.is_yaku_func(state, player, branch)) {
+        continue;
+      }
+      switch (yaku.type) {
+        case Yaku::kOpen:
+        case Yaku::kClosed:
+          branchscore.han += yaku.value;
+          break;
+        case Yaku::kBonusWhenClosed:
+          branchscore.han += yaku.value + (state.hands[player].open ? 0 : 1);
+          break;
+        case Yaku::kYakuman:
+          branchscore.yakuman++;
+          break;
+      }
     }
-    for (const auto& yaku_function : yaku::kYakumanFunctions) {
-      branchscore.yakuman += yaku_function(state, player, branch);
-    }
+
     for (const auto& dora : state.walls.GetDoras()) {
       for (const auto& p : state.hands.at(player).live) {
         if (p == dora) {
@@ -253,16 +268,11 @@ bool isComplete(const GameState& state, int player) {
         })) {
       continue;
     }
-
-    for (const auto& yaku_function : yaku::kYakuFunctions) {
-      if (yaku_function(state, player, branch) > 0) {
-        return true;
-      }
-    }
-    for (const auto& yaku_function : yaku::kYakumanFunctions) {
-      if (yaku_function(state, player, branch) > 0) {
-        return true;
-      }
+    if (std::ranges::any_of(Yakus::GetYakus(),
+                            [&state, player, &branch](const auto& yaku) {
+                              return yaku.is_yaku_func(state, player, branch);
+                            })) {
+      return true;
     }
   }
 

--- a/src/scoring/yakus.cc
+++ b/src/scoring/yakus.cc
@@ -1,0 +1,12 @@
+#include "scoring/yakus.h"
+#include <vector>
+#include "types/yaku.h"
+
+namespace mahjong {
+const std::vector<Yaku>& Yakus::GetYakus() {
+  return Instance().yakus_;
+}
+void Yakus::RegisterYaku(Yaku&& yaku) {
+  return Instance().yakus_.push_back(yaku);
+}
+}  // namespace mahjong

--- a/src/scoring/yakus.cc
+++ b/src/scoring/yakus.cc
@@ -4,15 +4,15 @@
 
 namespace mahjong {
 const std::vector<Yaku>& Yakus::GetYakus() {
-  return Instance().yakus_;
+  return yakus_;
 }
 bool Yakus::RegisterYaku(const Yaku& yaku) {
-  Instance().yakus_.push_back(yaku);
+  yakus_.push_back(yaku);
   return true;
 }
 bool Yakus::RegisterYakus(const std::vector<Yaku>& yakus) {
   for (const auto& yaku : yakus) {
-    Instance().yakus_.push_back(yaku);
+    yakus_.push_back(yaku);
   }
   return true;
 }

--- a/src/scoring/yakus.cc
+++ b/src/scoring/yakus.cc
@@ -6,7 +6,14 @@ namespace mahjong {
 const std::vector<Yaku>& Yakus::GetYakus() {
   return Instance().yakus_;
 }
-void Yakus::RegisterYaku(Yaku&& yaku) {
-  return Instance().yakus_.push_back(yaku);
+bool Yakus::RegisterYaku(const Yaku& yaku) {
+  Instance().yakus_.push_back(yaku);
+  return true;
+}
+bool Yakus::RegisterYakus(const std::vector<Yaku>& yakus) {
+  for (const auto& yaku : yakus) {
+    Instance().yakus_.push_back(yaku);
+  }
+  return true;
 }
 }  // namespace mahjong

--- a/src/scoring/yakus.h
+++ b/src/scoring/yakus.h
@@ -5,7 +5,8 @@ namespace mahjong {
 class Yakus {
  public:
   static const std::vector<Yaku>& GetYakus();
-  static void RegisterYaku(Yaku&& yaku);
+  static bool RegisterYaku(const Yaku& yaku);
+  static bool RegisterYakus(const std::vector<Yaku>& yakus);
 
  private:
   Yakus() = default;
@@ -17,9 +18,14 @@ class Yakus {
   std::vector<Yaku> yakus_;
 };
 
-#define REGISTER_YAKU(yaku)     \
-  namespace {                   \
-  Yakus::RegisterYaku(&(yaku)); \
+#define REGISTER_YAKU(...)                                     \
+  namespace {                                                  \
+  bool __registered = Yakus::RegisterYaku((Yaku __VA_ARGS__)); \
+  }
+
+#define REGISTER_YAKUS(...)                                                 \
+  namespace {                                                               \
+  bool __registered = Yakus::RegisterYakus(std::vector<Yaku>(__VA_ARGS__)); \
   }
 
 }  // namespace mahjong

--- a/src/scoring/yakus.h
+++ b/src/scoring/yakus.h
@@ -4,28 +4,30 @@
 namespace mahjong {
 class Yakus {
  public:
-  static const std::vector<Yaku>& GetYakus();
-  static bool RegisterYaku(const Yaku& yaku);
-  static bool RegisterYakus(const std::vector<Yaku>& yakus);
-
- private:
-  Yakus() = default;
   static Yakus& Instance() {
     static Yakus yakus;
     return yakus;
   }
 
+  const std::vector<Yaku>& GetYakus();
+  bool RegisterYaku(const Yaku& yaku);
+  bool RegisterYakus(const std::vector<Yaku>& yakus);
+
+ private:
+  Yakus() = default;
+
   std::vector<Yaku> yakus_;
 };
 
-#define REGISTER_YAKU(...)                                     \
-  namespace {                                                  \
-  bool __registered = Yakus::RegisterYaku((Yaku __VA_ARGS__)); \
+#define REGISTER_YAKU(...)                                                \
+  namespace {                                                             \
+  bool __registered = Yakus::Instance().RegisterYaku((Yaku __VA_ARGS__)); \
   }
 
-#define REGISTER_YAKUS(...)                                                 \
-  namespace {                                                               \
-  bool __registered = Yakus::RegisterYakus(std::vector<Yaku>(__VA_ARGS__)); \
+#define REGISTER_YAKUS(...)                                            \
+  namespace {                                                          \
+  bool __registered =                                                  \
+      Yakus::Instance().RegisterYakus(std::vector<Yaku>(__VA_ARGS__)); \
   }
 
 }  // namespace mahjong

--- a/src/scoring/yakus.h
+++ b/src/scoring/yakus.h
@@ -1,80 +1,25 @@
 #pragma once
-#include <array>
 #include "types/yaku.h"
 
-#include "scoring/yakus/afterakan.h"
-#include "scoring/yakus/allgreen.h"
-#include "scoring/yakus/allhonors.h"
-#include "scoring/yakus/allpons.h"
-#include "scoring/yakus/allsimples.h"
-#include "scoring/yakus/allterminals.h"
-#include "scoring/yakus/allterminalsandhonors.h"
-#include "scoring/yakus/bigfourwinds.h"
-#include "scoring/yakus/bigthreedragons.h"
-#include "scoring/yakus/blessingofearth.h"
-#include "scoring/yakus/blessingofheaven.h"
-#include "scoring/yakus/blessingofman.h"
-#include "scoring/yakus/bottomofthesea.h"
-#include "scoring/yakus/fourconcealedpon.h"
-#include "scoring/yakus/fourkans.h"
-#include "scoring/yakus/fullflush.h"
-#include "scoring/yakus/fullyconcealedhand.h"
-#include "scoring/yakus/halfflush.h"
-#include "scoring/yakus/honorpon.h"
-#include "scoring/yakus/littlefourwinds.h"
-#include "scoring/yakus/littlethreedragons.h"
-#include "scoring/yakus/mixedtriplechi.h"
-#include "scoring/yakus/ninegates.h"
-#include "scoring/yakus/outsidehand.h"
-#include "scoring/yakus/pinfu.h"
-#include "scoring/yakus/puredoublechi.h"
-#include "scoring/yakus/purestraight.h"
-#include "scoring/yakus/robbingakan.h"
-#include "scoring/yakus/sevenpairs.h"
-#include "scoring/yakus/terminalsinallsets.h"
-#include "scoring/yakus/thirteenorphans.h"
-#include "scoring/yakus/threeconcealedpons.h"
-#include "scoring/yakus/threekans.h"
-#include "scoring/yakus/triplepon.h"
-#include "scoring/yakus/twicepuredoublechi.h"
+namespace mahjong {
+class Yakus {
+ public:
+  static const std::vector<Yaku>& GetYakus();
+  static void RegisterYaku(Yaku&& yaku);
 
-namespace mahjong::yaku {
-constexpr int kNumYakus = 27;
-const std::array<yakuFunc, kNumYakus> kYakuFunctions{
-    isFullyConcealedHand,
-    isPinfu,
-    isPureDoubleChi,
-    isAllSimples,
-    isMixedTripleChi,
-    isPureStraight,
-    isPrevalentWind,
-    isSeatWind,
-    isGreenDragon,
-    isWhiteDragon,
-    isRedDragon,
-    isOutsideHand,
-    isAfterAKan,
-    isRobbingAKan,
-    isBottomOfTheSea,
-    isSevenPairs,
-    isTriplePon,
-    isThreeConcealedPons,
-    isThreeKans,
-    isAllPons,
-    isHalfFlush,
-    isLittleThreeDragons,
-    isAllTerminalsAndHonors,
-    isTerminalsInAllSets,
-    isTwicePureDoubleChi,
-    isBlessingOfMan,
-    isFullFlush,
-};
-constexpr int kNumYakuman = 12;
-const std::array<yakuFunc, kNumYakuman> kYakumanFunctions = {
-    isThirteenOrphans, isNineGates,        isBlessingOfHeaven,
-    isBlessingOfEarth, isFourConcealedPon, isFourKans,
-    isAllGreen,        isAllTerminals,     isAllHonors,
-    isBigThreeDragons, isLittleFourWinds,  isBigFourWinds,
+ private:
+  Yakus() = default;
+  static Yakus& Instance() {
+    static Yakus yakus;
+    return yakus;
+  }
+
+  std::vector<Yaku> yakus_;
 };
 
-}  // namespace mahjong::yaku
+#define REGISTER_YAKU(yaku)     \
+  namespace {                   \
+  Yakus::RegisterYaku(&(yaku)); \
+  }
+
+}  // namespace mahjong

--- a/src/scoring/yakus/afterakan.cc
+++ b/src/scoring/yakus/afterakan.cc
@@ -2,9 +2,11 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
 #include "types/statefunction.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isAfterAKan(const GameState& state, int player,
@@ -18,4 +20,11 @@ bool isAfterAKan(const GameState& state, int player,
   return false;
 }
 
+REGISTER_YAKU({
+    .id = "afterakan",
+    .name = "After a Kan",
+    .type = Yaku::kOpen,
+    .value = 1,
+    .is_yaku_func = yaku::isAfterAKan,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/allgreen.cc
+++ b/src/scoring/yakus/allgreen.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isAllGreen(const GameState& state, int player,
@@ -21,4 +23,11 @@ bool isAllGreen(const GameState& state, int player,
   return true;
 }
 
+REGISTER_YAKU({
+    .id = "allgreen",
+    .name = "All Green",
+    .type = Yaku::kYakuman,
+    .value = 13,
+    .is_yaku_func = yaku::isAllGreen,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/allhonors.cc
+++ b/src/scoring/yakus/allhonors.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isAllHonors(const GameState& state, int player,
@@ -21,4 +23,11 @@ bool isAllHonors(const GameState& state, int player,
   return true;
 }
 
+REGISTER_YAKU({
+    .id = "allhonors",
+    .name = "All Honors",
+    .type = Yaku::kYakuman,
+    .value = 13,
+    .is_yaku_func = yaku::isAllHonors,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/allpons.cc
+++ b/src/scoring/yakus/allpons.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isAllPons(const GameState& state, int player,
@@ -23,4 +25,11 @@ bool isAllPons(const GameState& state, int player,
   return pons == 4;
 }
 
+REGISTER_YAKU({
+    .id = "allpons",
+    .name = "All Pons",
+    .type = Yaku::kOpen,
+    .value = 2,
+    .is_yaku_func = yaku::isAllPons,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/allsimples.cc
+++ b/src/scoring/yakus/allsimples.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isAllSimples(const GameState& state, int player,
@@ -22,4 +24,11 @@ bool isAllSimples(const GameState& state, int player,
   return true;
 }
 
+REGISTER_YAKU({
+    .id = "allsimples",
+    .name = "All Simples",
+    .type = Yaku::kOpen,
+    .value = 1,
+    .is_yaku_func = yaku::isAllSimples,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/allterminals.cc
+++ b/src/scoring/yakus/allterminals.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isAllTerminals(const GameState& state, int player,
@@ -21,4 +23,11 @@ bool isAllTerminals(const GameState& state, int player,
   return true;
 }
 
+REGISTER_YAKU({
+    .id = "allterminals",
+    .name = "All Terminals",
+    .type = Yaku::kYakuman,
+    .value = 1,
+    .is_yaku_func = yaku::isAllTerminals,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/allterminalsandhonors.cc
+++ b/src/scoring/yakus/allterminalsandhonors.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isAllTerminalsAndHonors(
@@ -22,4 +24,11 @@ bool isAllTerminalsAndHonors(
   return true;
 }
 
+REGISTER_YAKU({
+    .id = "allterminalsandhonors",
+    .name = "All Terminals and Honors",
+    .type = Yaku::kOpen,
+    .value = 2,
+    .is_yaku_func = yaku::isAllTerminalsAndHonors,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/bigfourwinds.cc
+++ b/src/scoring/yakus/bigfourwinds.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isBigFourWinds(const GameState& state, int player,
@@ -39,4 +41,11 @@ bool isBigFourWinds(const GameState& state, int player,
   return pons == 4;
 }
 
+REGISTER_YAKU({
+    .id = "bigfourwinds",
+    .name = "Big Four Winds",
+    .type = Yaku::kYakuman,
+    .value = 13,
+    .is_yaku_func = yaku::isBigFourWinds,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/bigthreedragons.cc
+++ b/src/scoring/yakus/bigthreedragons.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isBigThreeDragons(const GameState& state, int player,
@@ -37,4 +39,11 @@ bool isBigThreeDragons(const GameState& state, int player,
   return pons == 3;
 }
 
+REGISTER_YAKU({
+    .id = "bigthreedragons",
+    .name = "Big Three Dragons",
+    .type = Yaku::kYakuman,
+    .value = 1,
+    .is_yaku_func = yaku::isBigThreeDragons,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/blessingofearth.cc
+++ b/src/scoring/yakus/blessingofearth.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isBlessingOfEarth(const GameState& state, int player,
@@ -23,4 +25,11 @@ bool isBlessingOfEarth(const GameState& state, int player,
   return true;
 }
 
+REGISTER_YAKU({
+    .id = "blessingofearth",
+    .name = "Blessing of Earth",
+    .type = Yaku::kYakuman,
+    .value = 13,
+    .is_yaku_func = yaku::isBlessingOfEarth,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/blessingofheaven.cc
+++ b/src/scoring/yakus/blessingofheaven.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isBlessingOfHeaven(const GameState& state, int player,
@@ -23,4 +25,11 @@ bool isBlessingOfHeaven(const GameState& state, int player,
   return true;
 }
 
+REGISTER_YAKU({
+    .id = "blessingofheaven",
+    .name = "Blessing of Heaven",
+    .type = Yaku::kYakuman,
+    .value = 13,
+    .is_yaku_func = yaku::isBlessingOfHeaven,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/blessingofman.cc
+++ b/src/scoring/yakus/blessingofman.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isBlessingOfMan(const GameState& state, int player,
@@ -23,4 +25,11 @@ bool isBlessingOfMan(const GameState& state, int player,
   return false;
 }
 
+REGISTER_YAKU({
+    .id = "blessingofman",
+    .name = "Blessing of Man",
+    .type = Yaku::kYakuman,
+    .value = 13,
+    .is_yaku_func = yaku::isBlessingOfMan,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/bottomofthesea.cc
+++ b/src/scoring/yakus/bottomofthesea.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isBottomOfTheSea(const GameState& state, int /*player*/,
@@ -11,4 +13,11 @@ bool isBottomOfTheSea(const GameState& state, int /*player*/,
   return state.walls.GetRemainingPieces() == 0;
 }
 
+REGISTER_YAKU({
+    .id = "bottomofthesea",
+    .name = "Bottom of the Sea",
+    .type = Yaku::kOpen,
+    .value = 1,
+    .is_yaku_func = yaku::isBottomOfTheSea,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/doubleriichi.cc
+++ b/src/scoring/yakus/doubleriichi.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isDoubleRiichi(const GameState& state, int player,
@@ -12,4 +14,11 @@ bool isDoubleRiichi(const GameState& state, int player,
          (state.turnNum < 4 && state.lastCall < 0);
 }
 
+REGISTER_YAKU({
+    .id = "doubleriichi",
+    .name = "Double Riichi",
+    .type = Yaku::kClosed,
+    .value = 2,
+    .is_yaku_func = yaku::isDoubleRiichi,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/fourconcealedpon.cc
+++ b/src/scoring/yakus/fourconcealedpon.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isFourConcealedPon(const GameState& state, int player,
@@ -25,4 +27,11 @@ bool isFourConcealedPon(const GameState& state, int player,
   return concealed_pons == 4;
 }
 
+REGISTER_YAKU({
+    .id = "fourconcealedpon",
+    .name = "Four Concealed Pon",
+    .type = Yaku::kYakuman,
+    .value = 13,
+    .is_yaku_func = yaku::isFourConcealedPon,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/fourkans.cc
+++ b/src/scoring/yakus/fourkans.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isFourKans(const GameState& state, int player,
@@ -17,4 +19,11 @@ bool isFourKans(const GameState& state, int player,
   return kans == 4;
 }
 
+REGISTER_YAKU({
+    .id = "fourkans",
+    .name = "Four Kans",
+    .type = Yaku::kYakuman,
+    .value = 1,
+    .is_yaku_func = yaku::isFourKans,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/fullflush.cc
+++ b/src/scoring/yakus/fullflush.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isFullFlush(const GameState& state, int player,
@@ -25,4 +27,11 @@ bool isFullFlush(const GameState& state, int player,
   return true;
 }
 
+REGISTER_YAKU({
+    .id = "fullflush",
+    .name = "Full Flush",
+    .type = Yaku::kBonusWhenClosed,
+    .value = 5,
+    .is_yaku_func = yaku::isFullFlush,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/fullyconcealedhand.cc
+++ b/src/scoring/yakus/fullyconcealedhand.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isFullyConcealedHand(const GameState& state, int player,
@@ -12,4 +14,11 @@ bool isFullyConcealedHand(const GameState& state, int player,
          state.walls.GetRemainingPieces() > 0;
 }
 
+REGISTER_YAKU({
+    .id = "fullyconcealedhand",
+    .name = "Fully Concealed Hand",
+    .type = Yaku::kClosed,
+    .value = 1,
+    .is_yaku_func = yaku::isFullyConcealedHand,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/halfflush.cc
+++ b/src/scoring/yakus/halfflush.cc
@@ -2,9 +2,11 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "scoring/yakus/fullflush.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isHalfFlush(const GameState& state, int player,
@@ -33,4 +35,11 @@ bool isHalfFlush(const GameState& state, int player,
   return honors && !isFullFlush(state, player);
 }
 
+REGISTER_YAKU({
+    .id = "halfflush",
+    .name = "Half Flush",
+    .type = Yaku::kBonusWhenClosed,
+    .value = 1,
+    .is_yaku_func = yaku::isHalfFlush,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/honorpon.cc
+++ b/src/scoring/yakus/honorpon.cc
@@ -2,12 +2,14 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "statefunctions/stateutilities.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
 #include "types/pieces.h"
 #include "types/piecetype.h"
 #include "types/winds.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 namespace {
@@ -56,4 +58,41 @@ bool isWhiteDragon(const GameState& state, int player,
   return findPon(state, player, branch, kWhiteDragon);
 }
 
+REGISTER_YAKUS({
+    {
+        .id = "seatwind",
+        .name = "Seat Wind Pon",
+        .type = Yaku::kOpen,
+        .value = 1,
+        .is_yaku_func = yaku::isSeatWind,
+    },
+    {
+        .id = "prevalentwind",
+        .name = "Prevalent Wind Pon",
+        .type = Yaku::kOpen,
+        .value = 1,
+        .is_yaku_func = yaku::isPrevalentWind,
+    },
+    {
+        .id = "greendragon",
+        .name = "Green Dragon Pon",
+        .type = Yaku::kOpen,
+        .value = 1,
+        .is_yaku_func = yaku::isGreenDragon,
+    },
+    {
+        .id = "reddragon",
+        .name = "Red Dragon Pon",
+        .type = Yaku::kOpen,
+        .value = 1,
+        .is_yaku_func = yaku::isRedDragon,
+    },
+    {
+        .id = "whitedragon",
+        .name = "White Dragon Pon",
+        .type = Yaku::kOpen,
+        .value = 1,
+        .is_yaku_func = yaku::isWhiteDragon,
+    },
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/ippatsu.cc
+++ b/src/scoring/yakus/ippatsu.cc
@@ -2,10 +2,12 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "scoring/yakus/doubleriichi.h"
 #include "scoring/yakus/riichi.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isIppatsu(const GameState& state, int player,
@@ -15,4 +17,11 @@ bool isIppatsu(const GameState& state, int player,
           state.lastCall < state.hands.at(player).riichiRound);
 }
 
+REGISTER_YAKU({
+    .id = "Ippastsu",
+    .name = "Ippastsu",
+    .type = Yaku::kClosed,
+    .value = 1,
+    .is_yaku_func = yaku::isIppatsu,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/littlefourwinds.cc
+++ b/src/scoring/yakus/littlefourwinds.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isLittleFourWinds(const GameState& state, int player,
@@ -47,4 +49,11 @@ bool isLittleFourWinds(const GameState& state, int player,
   return pons == 3 && pair;
 }
 
+REGISTER_YAKU({
+    .id = "littlefourwinds",
+    .name = "Little Four Winds",
+    .type = Yaku::kYakuman,
+    .value = 13,
+    .is_yaku_func = yaku::isLittleFourWinds,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/littlethreedragons.cc
+++ b/src/scoring/yakus/littlethreedragons.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isLittleThreeDragons(const GameState& state, int player,
@@ -43,4 +45,11 @@ bool isLittleThreeDragons(const GameState& state, int player,
   return pons == 2 && pair;
 }
 
+REGISTER_YAKU({
+    .id = "littlethreedragons",
+    .name = "Little Three Dragons",
+    .type = Yaku::kOpen,
+    .value = 2,
+    .is_yaku_func = yaku::isLittleThreeDragons,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/maxbranches.cc
+++ b/src/scoring/yakus/maxbranches.cc
@@ -54,4 +54,11 @@ bool isMaxBranches(const GameState& state, int player,
   return true;
 }
 
+// REGISTER_YAKU({
+//     .id = "maxbranches",
+//     .name = "Max Branches",
+//     .type = Yaku::kYakuman,
+//     .value = 13,
+//     .is_yaku_func = yaku::isMaxBranches,
+// });
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/mixedtriplechi.cc
+++ b/src/scoring/yakus/mixedtriplechi.cc
@@ -3,8 +3,10 @@
 #include <array>
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isMixedTripleChi(const GameState& state, int player,
@@ -47,4 +49,11 @@ bool isMixedTripleChi(const GameState& state, int player,
   return false;
 }
 
+REGISTER_YAKU({
+    .id = "mixedtriplechi",
+    .name = "Mixed Triple Chi",
+    .type = Yaku::kBonusWhenClosed,
+    .value = 1,
+    .is_yaku_func = yaku::isMixedTripleChi,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/ninegates.cc
+++ b/src/scoring/yakus/ninegates.cc
@@ -3,9 +3,11 @@
 #include <map>
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "scoring/yakus/fullflush.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isNineGates(const GameState& state, int player,
@@ -51,4 +53,11 @@ bool isNineGates(const GameState& state, int player,
   return true;
 }
 
+REGISTER_YAKU({
+    .id = "ninegates",
+    .name = "Nine Gates",
+    .type = Yaku::kYakuman,
+    .value = 1,
+    .is_yaku_func = yaku::isNineGates,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/outsidehand.cc
+++ b/src/scoring/yakus/outsidehand.cc
@@ -2,10 +2,12 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "scoring/yakus/allterminalsandhonors.h"
 #include "scoring/yakus/terminalsinallsets.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isOutsideHand(const GameState& state, int player,
@@ -42,4 +44,11 @@ bool isOutsideHand(const GameState& state, int player,
          !isAllTerminalsAndHonors(state, player);
 }
 
+REGISTER_YAKU({
+    .id = "outsidehand",
+    .name = "Outside Hand",
+    .type = Yaku::kBonusWhenClosed,
+    .value = 1,
+    .is_yaku_func = yaku::isOutsideHand,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/pinfu.cc
+++ b/src/scoring/yakus/pinfu.cc
@@ -4,10 +4,12 @@
 #include <vector>
 
 #include "analysis/util.h"
+#include "scoring/yakus.h"
 #include "statefunctions/stateutilities.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
 #include "types/pieces.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isPinfu(const GameState& state, int player,
@@ -47,4 +49,11 @@ bool isPinfu(const GameState& state, int player,
   return isInTenpai13Pieces(hand, /*allWaits=*/true).size() > 1;
 }
 
+REGISTER_YAKU({
+    .id = "pinfu",
+    .name = "Pinfu",
+    .type = Yaku::kClosed,
+    .value = 1,
+    .is_yaku_func = yaku::isPinfu,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/puredoublechi.cc
+++ b/src/scoring/yakus/puredoublechi.cc
@@ -3,8 +3,11 @@
 #include <cstddef>
 #include <vector>
 
+#include "scoring/yakus.h"
+#include "scoring/yakus/twicepuredoublechi.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isPureDoubleChi(const GameState& state, int player,
@@ -22,11 +25,18 @@ bool isPureDoubleChi(const GameState& state, int player,
       }
       if (branch.at(i)->type() == branch[j]->type() &&
           branch.at(i)->start() == branch[j]->start()) {
-        return true;
+        return !isTwicePureDoubleChi(state, player, branch);
       }
     }
   }
   return false;
 }
 
+REGISTER_YAKU({
+    .id = "puredoublechi",
+    .name = "PureDoubleChi",
+    .type = Yaku::kClosed,
+    .value = 1,
+    .is_yaku_func = yaku::isPureDoubleChi,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/purestraight.cc
+++ b/src/scoring/yakus/purestraight.cc
@@ -3,8 +3,10 @@
 #include <array>
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isPureStraight(const GameState& state, int player,
@@ -73,4 +75,11 @@ bool isPureStraight(const GameState& state, int player,
   return false;
 }
 
+REGISTER_YAKU({
+    .id = "purestraight",
+    .name = "Pure Straight",
+    .type = Yaku::kBonusWhenClosed,
+    .value = 1,
+    .is_yaku_func = yaku::isPureStraight,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/riichi.cc
+++ b/src/scoring/yakus/riichi.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isRiichi(const GameState& state, int player,
@@ -12,4 +14,11 @@ bool isRiichi(const GameState& state, int player,
          (state.turnNum > 4 || state.lastCall < 0);
 }
 
+REGISTER_YAKU({
+    .id = "riichi",
+    .name = "Riichi",
+    .type = Yaku::kClosed,
+    .value = 1,
+    .is_yaku_func = yaku::isRiichi,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/robbingakan.cc
+++ b/src/scoring/yakus/robbingakan.cc
@@ -2,9 +2,11 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
 #include "types/statefunction.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isRobbingAKan(const GameState& state, int player,
@@ -18,4 +20,11 @@ bool isRobbingAKan(const GameState& state, int player,
   return false;
 }
 
+REGISTER_YAKU({
+    .id = "robbingakan",
+    .name = "Robbing a Kan",
+    .type = Yaku::kOpen,
+    .value = 1,
+    .is_yaku_func = yaku::isRobbingAKan,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/sevenpairs.cc
+++ b/src/scoring/yakus/sevenpairs.cc
@@ -3,9 +3,11 @@
 #include <set>
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
 #include "types/piecetype.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isSevenPairs(const GameState& state, int player,
@@ -30,4 +32,11 @@ bool isSevenPairs(const GameState& state, int player,
   return pairs.size() == 7;
 }
 
+REGISTER_YAKU({
+    .id = "sevenpairs",
+    .name = "Seven Pairs",
+    .type = Yaku::kClosed,
+    .value = 2,
+    .is_yaku_func = yaku::isSevenPairs,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/terminalsinallsets.cc
+++ b/src/scoring/yakus/terminalsinallsets.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isTerminalsInAllSets(const GameState& state, int player,
@@ -47,4 +49,11 @@ bool isTerminalsInAllSets(const GameState& state, int player,
   return true;
 }
 
+REGISTER_YAKU({
+    .id = "terminalsinallsets",
+    .name = "Terminals in all Sets",
+    .type = Yaku::kBonusWhenClosed,
+    .value = 2,
+    .is_yaku_func = yaku::isTerminalsInAllSets,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/thirteenorphans.cc
+++ b/src/scoring/yakus/thirteenorphans.cc
@@ -3,10 +3,12 @@
 #include <map>
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
 #include "types/pieces.h"
 #include "types/piecetype.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isThirteenOrphans(const GameState& state, int player,
@@ -41,4 +43,11 @@ bool isThirteenOrphans(const GameState& state, int player,
   return true;
 }
 
+REGISTER_YAKU({
+    .id = "thirteenorphans",
+    .name = "Thirteen Orphans",
+    .type = Yaku::kYakuman,
+    .value = 1,
+    .is_yaku_func = yaku::isThirteenOrphans,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/threeconcealedpons.cc
+++ b/src/scoring/yakus/threeconcealedpons.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isThreeConcealedPons(const GameState& state, int player,
@@ -22,4 +24,11 @@ bool isThreeConcealedPons(const GameState& state, int player,
   return concealed_pons >= 3;
 }
 
+REGISTER_YAKU({
+    .id = "threeconcealedpons",
+    .name = "Three Concealed Pons",
+    .type = Yaku::kOpen,
+    .value = 2,
+    .is_yaku_func = yaku::isThreeConcealedPons,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/threekans.cc
+++ b/src/scoring/yakus/threekans.cc
@@ -2,8 +2,10 @@
 
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isThreeKans(const GameState& state, int player,
@@ -17,4 +19,11 @@ bool isThreeKans(const GameState& state, int player,
   return kans >= 3;
 }
 
+REGISTER_YAKU({
+    .id = "threekans",
+    .name = "Three Kans",
+    .type = Yaku::kOpen,
+    .value = 2,
+    .is_yaku_func = yaku::isThreeKans,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/triplepon.cc
+++ b/src/scoring/yakus/triplepon.cc
@@ -3,8 +3,10 @@
 #include <array>
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isTriplePon(const GameState& state, int player,
@@ -46,4 +48,11 @@ bool isTriplePon(const GameState& state, int player,
   return false;
 }
 
+REGISTER_YAKU({
+    .id = "triplepon",
+    .name = "Triple Pon",
+    .type = Yaku::kOpen,
+    .value = 2,
+    .is_yaku_func = yaku::isTriplePon,
+});
 }  // namespace mahjong::yaku

--- a/src/scoring/yakus/twicepuredoublechi.cc
+++ b/src/scoring/yakus/twicepuredoublechi.cc
@@ -3,8 +3,10 @@
 #include <cstddef>
 #include <vector>
 
+#include "scoring/yakus.h"
 #include "types/gamestate.h"
 #include "types/handnode.h"
+#include "types/yaku.h"
 
 namespace mahjong::yaku {
 bool isTwicePureDoubleChi(const GameState& state, int player,
@@ -27,4 +29,11 @@ bool isTwicePureDoubleChi(const GameState& state, int player,
   return pairs == 2;
 }
 
+REGISTER_YAKU({
+    .id = "twicepuredoublechi",
+    .name = "Twice Pure Double Chi",
+    .type = Yaku::kClosed,
+    .value = 3,
+    .is_yaku_func = yaku::isTwicePureDoubleChi,
+});
 }  // namespace mahjong::yaku

--- a/src/types/yaku.h
+++ b/src/types/yaku.h
@@ -9,58 +9,19 @@ namespace mahjong {
 using yakuFunc = std::function<int(const mahjong::GameState&, int,
                                    const std::vector<const mahjong::Node*>&)>;
 
-enum class YakuId {
-  kRiichi,
-  kDoubleRiichi,
-  kIppatsu,
-  kFullyConcealedHand,
-  kPinfu,
-  kPureDoubleChi,
-  kAllSimples,
-  kMixedTripleChi,
-  kPureStraight,
-  kSeatWind,
-  kPrevalentWind,
-  kWhiteDragon,
-  kGreenDragon,
-  kRedDragon,
-  kOutsideHand,
-  kAfterAKan,
-  kRobbingAKan,
-  kBottomofTheSea,
-  kSevenPairs,
-  kTriplePon,
-  kThreeConcealedPons,
-  kThreeKans,
-  kAllPons,
-  kHalfFlush,
-  kLittleThreeDragons,
-  kAllTerminalsAndHonors,
-  kTerminalsInAllSets,
-  kTwicePureDoubleChi,
-  kFullFlush,
-  kThirteenOrphans,
-  kNineGates,
-  kBlessingOfHeaven,
-  kBlessingofMan,
-  kBlessingOfEarth,
-  kFourConcealedPon,
-  kFourKans,
-  kAllGreen,
-  kAllTerminals,
-  kAllHonors,
-  kBigThreeDragons,
-  kLittleFourWinds,
-  kBigFourWinds,
-  kMaxBranches,
-};
+using Han = int;
 
 struct Yaku {  // add yakus for exclusions, name, and enum possibly
-  const YakuId id;
+  enum Type {
+    kOpen,
+    kClosed,
+    kBonusWhenClosed,
+    kYakuman,
+  };
+  const std::string id;
   const std::string name;
+  const Type type;
+  const Han value;
   const yakuFunc is_yaku_func;
-  const std::vector<YakuId> doesnt_score_with;
-  const int han;
-  const bool bonus_when_closed;
 };
 }  // namespace mahjong


### PR DESCRIPTION
Re-add Han to scoring via Yaku registration. 

I think in a future batch of changes I want to use this register yaku solely to match a yaku id to a given check and then have the other information in like a toml file or similar. That way we can separate the data from the code a bit more.

In the long run I think creating lua bindings would be cool to allow for external yaku definitions to be loaded at runtime.