### PR TITLE
Fix Nix Building for Gamestate to POD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,19 +11,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - toolchain: gcc
-          - toolchain: clang
-      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v30
       - name: Build using Nix
         run: |
-          nix build -L '.#${{ matrix.toolchain }}'
+          nix build -L
   test:
     name: Run ctests
     runs-on: ubuntu-latest

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756862479,
-        "narHash": "sha256-IkiKGgQ6UyuG/IXrMKBdcpgk5hTJyVVuuBKh5yFeEyM=",
+        "lastModified": 1757136376,
+        "narHash": "sha256-hjalxX39HdnLZ8cc03sniOd+WhT9sPE09EXeYCj5te0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dbc93ac7cdc0c1611a1bed3b1b14d5ff61389a6a",
+        "rev": "a50c9f77d238909b5f96d97dab0f69d1c9abefa8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           ninja
         ];
 
-        llvmPackage = pkgs.llvmPackages_20;
+        llvmPackage = pkgs.llvmPackages_19;
 
         # Override the existing gtest package to use clang
         clangGtest = pkgs.gtest.override {
@@ -89,25 +89,6 @@
         };
 
         packages = rec {
-          gcc = pkgs.stdenv.mkDerivation (
-            commonAttrs
-            // {
-              nativeBuildInputs = buildPackages;
-              # Add any runtime dependencies your library needs
-              propagatedBuildInputs = with pkgs; [
-                # Add dependencies that users of your library will need
-              ];
-
-              # This ensures dependent packages can find your library
-              setupHook = pkgs.writeText "setup-hook.sh" ''
-                addLibmahjongLibs() {
-                  addToSearchPath LD_LIBRARY_PATH $1/lib
-                }
-                addEnvHooks "$targetOffset" addLibmahjongLibs
-              '';
-            }
-          );
-
           clang = llvmPackage.stdenv.mkDerivation (
             commonAttrs
             // {


### PR DESCRIPTION
- Clang building fixed, needed to downgrade to llvm package 19 because of some regressions in the nix configurations
- GCC via Nix doesn't seem to support it? it's very strange, but removed it for now